### PR TITLE
Fortran code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+
 language: python
 python:
   - "2.7"
@@ -17,6 +18,7 @@ before_install:
   - pip install matplotlib
   - pip install pytest-cov
   - pip install python-coveralls
+  - pip install cpp-coveralls
   - pip install -e .
 
 install: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,10 @@ before_install:
   - pip install recommonmark
   - pip install matplotlib
   - pip install pytest-cov
-  - pip install python-coveralls
   - pip install cpp-coveralls
+  - pip install coveralls
+  - sudo apt-get install -y lcov
+  - gem install coveralls-lcov
   - pip install -e .
 
 install: 
@@ -28,7 +30,8 @@ script:
   - ARONNAX_TEST_VALGRIND_ALL=1 pytest --cov=aronnax
 
 after_success:
-  - gcov aronnax.gcda > coverage.json
+  - lcov --compat-libtool --directory . --capture --output-file coverage.info
+  - coveralls-lcov -v -n coverage.info > coverage.json
   - coveralls --merge=coverage.json
   - cd benchmarks
   - python benchmark.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,8 @@ script:
   - ARONNAX_TEST_VALGRIND_ALL=1 pytest --cov=aronnax
 
 after_success:
-  - coveralls
+  - gcov aronnax.gcda > coverage.json
+  - coveralls --merge=coverage.json
   - cd benchmarks
   - python benchmark.py
   - cd ../docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,6 @@ before_install:
   - pip install matplotlib
   - pip install pytest-cov
   - pip install codecov
-#  - pip install cpp-coveralls
-#  - pip install coveralls
-#  - sudo apt-get install -y lcov
-#  - gem install coveralls-lcov
   - pip install -e .
 
 install: 
@@ -29,14 +25,9 @@ install:
 script:
   - gfortran -Wall -Werror aronnax.f90
   - ARONNAX_TEST_VALGRIND_ALL=1 pytest --cov=aronnax
-#  - bash <(curl -s https://codecov.io/bash) -cF python
 
 after_success:
-#  - lcov --compat-libtool --directory . --capture --output-file coverage.info
-#  - coveralls-lcov -v -n coverage.info > coverage.json
-#  - coveralls --merge=coverage.json
   - codecov
-  - bash <(curl -s https://codecov.io/bash)
   - cd benchmarks
   - python benchmark.py
   - cd ../docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,11 @@ before_install:
   - pip install recommonmark
   - pip install matplotlib
   - pip install pytest-cov
-  - pip install cpp-coveralls
-  - pip install coveralls
-  - sudo apt-get install -y lcov
-  - gem install coveralls-lcov
+  - pip install codecov
+#  - pip install cpp-coveralls
+#  - pip install coveralls
+#  - sudo apt-get install -y lcov
+#  - gem install coveralls-lcov
   - pip install -e .
 
 install: 
@@ -28,11 +29,14 @@ install:
 script:
   - gfortran -Wall -Werror aronnax.f90
   - ARONNAX_TEST_VALGRIND_ALL=1 pytest --cov=aronnax
+#  - bash <(curl -s https://codecov.io/bash) -cF python
 
 after_success:
-  - lcov --compat-libtool --directory . --capture --output-file coverage.info
-  - coveralls-lcov -v -n coverage.info > coverage.json
-  - coveralls --merge=coverage.json
+#  - lcov --compat-libtool --directory . --capture --output-file coverage.info
+#  - coveralls-lcov -v -n coverage.info > coverage.json
+#  - coveralls --merge=coverage.json
+  - codecov
+  - bash <(curl -s https://codecov.io/bash)
   - cd benchmarks
   - python benchmark.py
   - cd ../docs

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ aronnax_core: aronnax.f90 Makefile
 	gfortran -g -Ofast $< -o $@
 
 aronnax_test: aronnax.f90 Makefile
-	gfortran -g -O1 -fcheck=all $< -o $@
+	gfortran -g -fprofile-arcs -ftest-coverage -O1 -fcheck=all $< -o $@
 
 aronnax_prof: aronnax.f90 Makefile
 	gfortran -g -pg -Ofast $< -o $@

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ aronnax_prof: aronnax.f90 Makefile
 	mpif90 -g -pg -Ofast $< -o $@ -cpp
 
 aronnax_external_solver_test: aronnax.f90 Makefile
-	mpif90 -g -O1 $< -o $@ -cpp -DuseExtSolver $(LIBS)
+	mpif90 -g -fprofile-arcs -ftest-coverage -O1 $< -o $@ -cpp -DuseExtSolver $(LIBS)
 
 aronnax_external_solver: aronnax.f90 Makefile
 	mpif90 -g -Ofast $< -o $@ -cpp -DuseExtSolver $(LIBS)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/edoddridge/aronnax.svg?branch=master)](https://travis-ci.org/edoddridge/aronnax)
-[![Coverage Status](https://coveralls.io/repos/github/edoddridge/aronnax/badge.svg?branch=master)](https://coveralls.io/github/edoddridge/aronnax?branch=master)
+[![codecov](https://codecov.io/gh/edoddridge/aronnax/branch/master/graph/badge.svg)](https://codecov.io/gh/edoddridge/aronnax)
 
 # Aronnax
 


### PR DESCRIPTION
Coveralls made it difficult to measure code coverage for both the Fortran and Python code in a cohesive way. Codecov does it very easily and amalgamates the results automatically.

The code coverage tool assesses only the code that is run by the test suite. The test suite does not currently run any of the Hypre code. This PR successfully implements an automated method to show that deficiency.