### PR TITLE
Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # Aronnax
 
-An idealized isopycnal ocean circulation model that can either be run
+An idealised isopycnal ocean circulation model that can either be run
 as a reduced gravity model with n + 1/2 layers, or with n layers and
 variable bathymetry.
 
@@ -14,10 +14,7 @@ Aronnax is
 - Easy to configure.  All parameters, including grid size, are
   specified at runtime in a simple configuration file.
 - [Easy to use](https://edoddridge.github.io/aronnax/examples.html).
-  Aronnax can be called as a simple command-line program
-  that reads and writes the standard NetCDF data format, or can be
-  controlled programmatically as a Python library, communicating data
-  through Numpy arrays.
+  Aronnax can be controlled programmatically as a Python library.
 - Easy to learn and understand, with extensive [online
   documentation](https://edoddridge.github.io/aronnax/), including a
   complete description of [the
@@ -25,8 +22,8 @@ Aronnax is
   and [the
   numerics](https://edoddridge.github.io/aronnax/about_aronnax.html#discretisation).
 - [Verified](https://edoddridge.github.io/aronnax/verification.html).
-  Aronnax successfully reproduces multiple published results from
-  idealized models appearing in the literature.
+  Aronnax successfully [reproduces published results](https://edoddridge.github.io/aronnax/examples.html#reproducing-published-results) from
+  idealised models appearing in the literature.
 - [Fast](https://edoddridge.github.io/aronnax/benchmarks.html).  The
   main integration loop is a multi-core Fortran program, wrapped in
   Python for convenient use.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ as a reduced gravity model with n + 1/2 layers, or with n layers and
 variable bathymetry.
 
 Aronnax is
-- [Easy to install](https://github.com/edoddridge/aronnax#install)
+- [Easy to install](https://edoddridge.github.io/aronnax/installation.html)
   on a laptop or a compute node, including without
   administrative privileges.
 - Easy to configure.  All parameters, including grid size, are
@@ -31,9 +31,6 @@ Aronnax is
   main integration loop is a multi-core Fortran program, wrapped in
   Python for convenient use.
 
-# Install
-
-todo
 
 # Get Involved
 

--- a/aronnax.conf
+++ b/aronnax.conf
@@ -80,8 +80,8 @@ rho0 = 1035.
 # layers is the number of active layers
 # dx is the x grid spacing in metres
 # dy is the y grid spacing in metres
-# fUfile defines the Coriolis parameter on the u grid points
-# fVfile defines the Coriolis parameter on the v grid points
+# fUfile defines the Coriolis parameter on the u grid points in 1/s
+# fVfile defines the Coriolis parameter on the v grid points in 1/s
 # wetMaskFile defines the computational domain - which grid points are ocean and
 #   which are land
 

--- a/aronnax.conf
+++ b/aronnax.conf
@@ -82,8 +82,9 @@ rho0 = 1035.
 # dy is the y grid spacing in metres
 # fUfile defines the Coriolis parameter on the u grid points in 1/s
 # fVfile defines the Coriolis parameter on the v grid points in 1/s
-# wetMaskFile defines the computational domain - which grid points are ocean and
-#   which are land
+# wetMaskFile defines the computational domain - which grid points are ocean, 
+#   with wetmask=1, and which are land, with wetmask=0. The wetmask is defined 
+#   at the centre of each grid cell, the same location as thickness.
 
 [grid]
 nx = 10

--- a/aronnax.conf
+++ b/aronnax.conf
@@ -18,6 +18,11 @@
 # botDrag is the linear bottom friction in 1/s
 # thickness_error is the  discrepancy between the summed layer thicknesses and 
 #   the depth above which the model emits a warning. 1e-2 is a 1% discrepancy.
+# debug_level controls the level of output produced by the model. When set to
+#   zero, or not specified (it defaults to zero), the model outputs h, u, and v
+#   at the frequency controlled by dumpFreq and avFreq. Specifying larger
+#   integer values results in progressively more output more frequently. See
+#   the documentation for details.
 
 [numerics]
 au = 500.
@@ -34,6 +39,7 @@ eps = 1e-5
 freesurfFac = 0.
 botDrag = 1e-6
 thickness_error = 1e-2
+debug_level = 0
 #------------------------------------------------------------------------------
 
 # RedGrav selects whether to use n+1/2 layer physics (RedGrav=yes), or n-layer 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -77,7 +77,7 @@ The y component of the normalised wind stress field is shown on the left, and th
    :width: 62%
 
 
-After integrating for 40 model years these inputs produce a steady seasonal cyclein velocity and layer thickness. A snap shot is shown on the left, while a time series of the maximum thickness is shown on the right.
+After integrating for 40 model years these inputs produce a steady seasonal cycle in velocity and layer thickness. A snap shot is shown on the left, while a time series of the maximum thickness is shown on the right.
 
 .. image:: ../reproductions/Davis_et_al_2014/control_final_five/figures/state_0000155089.png
    :width: 37%

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,7 @@ Aronnax can be run as either a reduced gravity model with n + 1/2 layers, or wit
 
 Aronnax is
 
-- `Easy to install <https://github.com/edoddridge/aronnax#install>`_
+- `Easy to install <installation.html>`_
   on a laptop or a compute node, including without
   administrative privileges.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,12 +41,12 @@ Aronnax is
    :maxdepth: 2
    :caption: Contents:
 
-   examples
    aronnax_model
    installation
    input_generation
    running_aronnax
    output_helpers
+   examples
    verification
    benchmarks
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,20 +1,43 @@
+.. role:: bash(code)
+   :language: bash
+
 Installation
 ************************
 
 
-To do - make this simpler
+While we aspire for the installation process for Aronnax to be as simple as :code:`pip install aronnax`, it is not yet that easy.
 
 Dependencies
 ============
-Aronnax depends on several external libraries, namely, make, gfortran, and mpi. It also depends on numpy and scipy.
+Aronnax depends on several external libraries, namely, make, gfortran, and mpi. This means you will need a working installation of each of these. In particular, Aronnax will need the :bash:`mpif90` command to work in order for it to compile its Fortran core.
+
+Aronnax also depends on numpy and scipy.
+
 
 Installation instructions
 =========================
 
- #. Clone the repository
+ #. Clone the repository to a local directory
+
+    - :bash:`git clone https://github.com/edoddridge/aronnax.git`
+
  #. Compile Hypre
 
-    - move to the directory 'lib/hypre'
-    - follow installation instructions for Hypre
+    - move to the directory 'lib/hypre/src'
 
- #. run :code:`pip install -e .` to install Aronnax
+      - :bash:`cd lib/hypre/src`
+    
+    - configure the Hypre installer
+
+      - :bash:`./configure`
+
+    - compile Hypre. This will take a few minutes
+      
+      - :bash:`make install`
+
+ #. install Aronnax
+   
+    - :code:`pip install -e .`
+
+Aronnax is now installed and ready to use. To verify that everything is working, you may wish to run the test suite. Do this by executing :code:`pytest` in the base directory of the repository. This requires that the pytest module is installed.
+

--- a/docs/running_aronnax.rst
+++ b/docs/running_aronnax.rst
@@ -37,3 +37,14 @@ The example file is reproduced here with comments describing the parameters and 
 
 .. warning::
     The configuration file shown above includes all of the possible input parameters and fields since it forms part of the documentation. IT WILL NOT WORK AS IS. To use it in an actual simulation the file will need to be modified either by giving values to the parameters that are currently unspecified, or deleting them from the file. If you wish to see a configuration file that corresponds to a successful simulation, look in any of the test, benchmark, or reproduction directories.
+
+debug_level
+-----------
+This parameter determines whether the model produces additional outputs. It should be set to an integer value greater than or equal to zero. The different values have the following effects:
+
+ - 0: no additional outputs. Output frequency controlled by `DumpFreq` and `AvFreq`
+ - 1: output tendencies at frequency given by `DumpFreq`
+ - 2: output tendencies and convergence diagnostics from the linear solve at frequency given by `DumpFreq` (not implemented)
+ - 3: output convergence diagnostics and tendencies before and after applying some or all of sponges, barotropic correction, winds, and boundary conditions at frequency controlled by `DumpFreq` (not implemented)
+ - 4: dump all of the above fields every time step (mostly implemented)
+ - 5: dump everything every time step including the two initial RK4 steps (not implemented)


### PR DESCRIPTION
A grad bag of small enhancements for the documentation.

Added units to Coriolis parameter in config file and described wetmask values, closing #58.
Fixed typo in Davis et al. (2014) reproduction, closing #142.
Described debug_level in more detail.
Added installation instructions for building Hypre locally, closing #126.
Tweaked readme to less aspirational, and more realistic.