### PR TITLE
Move all arrays off the stack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,6 @@ script:
   - codecov
   - python test/periodic_BC_Hypre.py
   - codecov
-
-after_success:
   - cd reproductions
   - python run_davis_et_al_2014.py
   - python plot_Davis_et_al_2014.py
@@ -44,6 +42,8 @@ after_success:
   - python benchmark.py
   - cd ../test
   - python physics_tests.py
+
+after_success:
   - cd ../docs
   - make html
   - cd _build/html

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 python:
   - "2.7"
 
+dist: trusty
 sudo: required
 
 branches:

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ HYPRE_DIR = lib/hypre/src
 LIBS      = -L$(HYPRE_DIR)/lib -lHYPRE -lm
 
 aronnax_core: aronnax.f90 Makefile
-	mpif90 -g -Ofast $< -o $@ -cpp
+	mpif90 -g -Ofast -fno-stack-arrays $< -o $@ -cpp
 
 aronnax_test: aronnax.f90 Makefile
 	mpif90 -g -fprofile-arcs -ftest-coverage -O1 -fcheck=all $< -o $@ -cpp
@@ -16,4 +16,4 @@ aronnax_external_solver_test: aronnax.f90 Makefile
 	mpif90 -g -fprofile-arcs -ftest-coverage -O1 $< -o $@ -cpp -DuseExtSolver $(LIBS)
 
 aronnax_external_solver: aronnax.f90 Makefile
-	mpif90 -g -Ofast $< -o $@ -cpp -DuseExtSolver $(LIBS)
+	mpif90 -g -Ofast -fno-stack-arrays $< -o $@ -cpp -DuseExtSolver $(LIBS)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -9,7 +9,7 @@ While we aspire for the installation process for Aronnax to be as simple as :cod
 
 Dependencies
 ============
-Aronnax depends on several external libraries, namely, make, gfortran, and mpi. This means you will need a working installation of each of these. In particular, Aronnax will need the :bash:`mpif90` command to work in order for it to compile its Fortran core.
+Aronnax depends on several external libraries, namely, make, gfortran >= 4.7.4, and mpi. This means you will need a working installation of each of these. In particular, Aronnax will need the :bash:`mpif90` command to work in order for it to compile its Fortran core.
 
 Aronnax also depends on numpy and scipy.
 


### PR DESCRIPTION
As discussed in #73, the model would segfault when it tried to place very large arrays on the stack. The workaround introduced in #72 involved using allocate commands to prevent the arrays from being placed on the stack. However, it was still possible, when running simulations with large grids, to exceed the stack limits and have the model segfault. This PR uses the compiler flag `-fno-stack-arrays` to keep arrays off the stack, and removes the allocate commands, thereby simplifying the source code and improving readability. As discussed in #73, doing this does not affect performance.