### PR TITLE
Add restart functionality

### DIFF
--- a/aronnax.conf
+++ b/aronnax.conf
@@ -6,9 +6,13 @@
 # ar is linear drag between layers in 1/s
 # dt is time step in seconds
 # slip is free-slip (=0), no-slip (=1), or partial slip (something in between)
+# niter0: the timestep at which the simulation begins. If not zero, then there 
+#   must be checkpoint files in the 'checkpoints' directory.
 # nTimeSteps: number of timesteps before stopping
 # dumpFreq: time between snapshot outputs in seconds
 # avFreq: time between averaged output in seconds
+# checkpiontFreq: time between checkpoints in seconds 
+#   (these are used for restarting simulations)
 # hmin: minimum layer thickness allowed by model (for stability) in metres
 # maxits: maximum iterations for the pressure solver algorithm. Should probably
 #   be at least max(nx,ny), and possibly nx*ny
@@ -30,9 +34,11 @@ ah = 0.0
 ar = 0.0
 dt = 600.
 slip = 0.0
+niter0 = 0
 nTimeSteps = 502
 dumpFreq = 1.2e5
 avFreq = 1.2e5
+checkpointFreq = 1.2e5
 hmin = 100
 maxits = 1000
 eps = 1e-5

--- a/aronnax.f90
+++ b/aronnax.f90
@@ -644,12 +644,12 @@ subroutine model_run(h, u, v, eta, depth, dx, dy, wetmask, fu, fv, &
     read(10) dvdtveryold
     close(10)
 
-
     if (.not. RedGrav) then
       open(unit=10, form='unformatted', file='checkpoints/eta.'//num)
       read(10) eta
       close(10)
     end if
+
   end if
 
   ! Now the model is ready to start.
@@ -772,6 +772,16 @@ subroutine model_run(h, u, v, eta, depth, dx, dy, wetmask, fu, fv, &
   cur_time = time()
   print "(A, I0, A, I0, A)", "Run finished at time step ", &
       n, ", in ", cur_time - start_time, " seconds."
+
+  ! save checkpoint at end of every simulation
+  call maybe_dump_output(h, hav, u, uav, v, vav, eta, etaav, &
+      dudt, dvdt, dhdt, &
+      dudtold, dvdtold, dhdtold, &
+      dudtveryold, dvdtveryold, dhdtveryold, &
+      wind_x, wind_y, nx, ny, layers, &
+      n, n, n, n-1, &
+      RedGrav, DumpWind, 0)
+
   return
 end subroutine model_run
 

--- a/aronnax.f90
+++ b/aronnax.f90
@@ -66,7 +66,7 @@ program aronnax
   double precision :: au, ar, botDrag
   double precision :: ah(layerwise_input_length)
   double precision :: slip, hmin
-  integer nTimeSteps
+  integer          :: niter0, nTimeSteps
   double precision :: dumpFreq, avFreq, checkpointFreq
   double precision, dimension(:),     allocatable :: zeros
   integer maxits
@@ -121,7 +121,8 @@ program aronnax
   ! TODO Possibly wait until the model is split into multiple files,
   ! then hide the long unsightly code there.
 
-  namelist /NUMERICS/ au, ah, ar, botDrag, dt, slip, nTimeSteps, &
+  namelist /NUMERICS/ au, ah, ar, botDrag, dt, slip, &
+      niter0, nTimeSteps, &
       dumpFreq, avFreq, checkpointFreq, hmin, maxits, freesurfFac, & 
       eps, thickness_error, debug_level
 
@@ -143,6 +144,7 @@ program aronnax
 
   ! Set default values here
   debug_level = 0
+  niter0 = 0
 
   
   open(unit=8, file="parameters.in", status='OLD', recl=80)
@@ -266,7 +268,8 @@ program aronnax
 
 
   call model_run(h, u, v, eta, depth, dx, dy, wetmask, fu, fv, &
-      dt, au, ar, botDrag, ah, slip, hmin, nTimeSteps, dumpFreq, avFreq, &
+      dt, au, ar, botDrag, ah, slip, hmin, niter0, nTimeSteps, &
+      dumpFreq, avFreq, &
       checkpointFreq, maxits, eps, freesurfFac, thickness_error, &
       debug_level, g_vec, rho0, &
       base_wind_x, base_wind_y, wind_mag_time_series, &
@@ -284,7 +287,8 @@ end program aronnax
 !> Run the model
 
 subroutine model_run(h, u, v, eta, depth, dx, dy, wetmask, fu, fv, &
-    dt, au, ar, botDrag, ah, slip, hmin, nTimeSteps, dumpFreq, avFreq, &
+    dt, au, ar, botDrag, ah, slip, hmin, niter0, nTimeSteps, &
+    dumpFreq, avFreq, &
     checkpointFreq, maxits, eps, freesurfFac, thickness_error, &
     debug_level, g_vec, rho0, &
     base_wind_x, base_wind_y, wind_mag_time_series, &
@@ -315,7 +319,7 @@ subroutine model_run(h, u, v, eta, depth, dx, dy, wetmask, fu, fv, &
   double precision, intent(in) :: dt, au, ar, botDrag
   double precision, intent(in) :: ah(layers)
   double precision, intent(in) :: slip, hmin
-  integer,          intent(in) :: nTimeSteps
+  integer,          intent(in) :: niter0, nTimeSteps
   double precision, intent(in) :: dumpFreq, avFreq, checkpointFreq
   integer,          intent(in) :: maxits
   double precision, intent(in) :: eps, freesurfFac, thickness_error
@@ -412,6 +416,9 @@ subroutine model_run(h, u, v, eta, depth, dx, dy, wetmask, fu, fv, &
   ! Time
   integer*8 :: start_time, last_report_time, cur_time
 
+  ! dummy variable for loading checkpoints
+  character(10)    :: num
+
 
   start_time = time()
   if (RedGrav) then
@@ -441,6 +448,7 @@ subroutine model_run(h, u, v, eta, depth, dx, dy, wetmask, fu, fv, &
 
   ! Pi, the constant
   pi = 3.1415926535897932384
+
 
   ! Initialize wind fields
   wind_x = base_wind_x*wind_mag_time_series(1)
@@ -495,100 +503,154 @@ subroutine model_run(h, u, v, eta, depth, dx, dy, wetmask, fu, fv, &
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   !!!  Initialisation of the model STARTS HERE                            !!!
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  !
-  ! Do two initial time steps with Runge-Kutta second-order.
-  ! These initialisation steps do NOT use or update the free surface.
-  !
-  ! ------------------------- negative 2 time step --------------------------
-  ! Code to work out dhdtveryold, dudtveryold and dvdtveryold
-  n = 0
-  
-  call state_derivative(dhdtveryold, dudtveryold, dvdtveryold, &
-      h, u, v, depth, &
-      dx, dy, wetmask, hfacW, hfacE, hfacN, hfacS, fu, fv, &
-      au, ar, botDrag, ah, slip, &
-      RedGrav, g_vec, rho0, wind_x, wind_y, &
-      spongeHTimeScale, spongeH, &
-      spongeUTimeScale, spongeU, &
-      spongeVTimeScale, spongeV, &
-      nx, ny, layers, n, debug_level)
+  if (niter0 .eq. 0) then
+    ! Do two initial time steps with Runge-Kutta second-order.
+    ! These initialisation steps do NOT use or update the free surface.
+    !
+    ! ------------------------- negative 2 time step --------------------------
+    ! Code to work out dhdtveryold, dudtveryold and dvdtveryold
+    n = 0
+    
+    call state_derivative(dhdtveryold, dudtveryold, dvdtveryold, &
+        h, u, v, depth, &
+        dx, dy, wetmask, hfacW, hfacE, hfacN, hfacS, fu, fv, &
+        au, ar, botDrag, ah, slip, &
+        RedGrav, g_vec, rho0, wind_x, wind_y, &
+        spongeHTimeScale, spongeH, &
+        spongeUTimeScale, spongeU, &
+        spongeVTimeScale, spongeV, &
+        nx, ny, layers, n, debug_level)
 
-  ! Calculate the values at half the time interval with Forward Euler
-  hhalf = h+0.5d0*dt*dhdtveryold
-  uhalf = u+0.5d0*dt*dudtveryold
-  vhalf = v+0.5d0*dt*dvdtveryold
+    ! Calculate the values at half the time interval with Forward Euler
+    hhalf = h+0.5d0*dt*dhdtveryold
+    uhalf = u+0.5d0*dt*dudtveryold
+    vhalf = v+0.5d0*dt*dvdtveryold
 
-  call state_derivative(dhdtveryold, dudtveryold, dvdtveryold, &
-      hhalf, uhalf, vhalf, depth, &
-      dx, dy, wetmask, hfacW, hfacE, hfacN, hfacS, fu, fv, &
-      au, ar, botDrag, ah, slip, &
-      RedGrav, g_vec, rho0, wind_x, wind_y, &
-      spongeHTimeScale, spongeH, &
-      spongeUTimeScale, spongeU, &
-      spongeVTimeScale, spongeV, &
-      nx, ny, layers, n, debug_level)
+    call state_derivative(dhdtveryold, dudtveryold, dvdtveryold, &
+        hhalf, uhalf, vhalf, depth, &
+        dx, dy, wetmask, hfacW, hfacE, hfacN, hfacS, fu, fv, &
+        au, ar, botDrag, ah, slip, &
+        RedGrav, g_vec, rho0, wind_x, wind_y, &
+        spongeHTimeScale, spongeH, &
+        spongeUTimeScale, spongeU, &
+        spongeVTimeScale, spongeV, &
+        nx, ny, layers, n, debug_level)
 
-  ! These are the values to be stored in the 'veryold' variables ready
-  ! to start the proper model run.
+    ! These are the values to be stored in the 'veryold' variables ready
+    ! to start the proper model run.
 
-  ! Calculate h, u, v with these tendencies
-  h = h + dt*dhdtveryold
-  u = u + dt*dudtveryold
-  v = v + dt*dvdtveryold
+    ! Calculate h, u, v with these tendencies
+    h = h + dt*dhdtveryold
+    u = u + dt*dudtveryold
+    v = v + dt*dvdtveryold
 
-  ! Apply the boundary conditions
-  call apply_boundary_conditions(u, hfacW, wetmask, nx, ny, layers)
-  call apply_boundary_conditions(v, hfacS, wetmask, nx, ny, layers)
+    ! Apply the boundary conditions
+    call apply_boundary_conditions(u, hfacW, wetmask, nx, ny, layers)
+    call apply_boundary_conditions(v, hfacS, wetmask, nx, ny, layers)
 
-  ! Wrap fields around for periodic simulations
-  call wrap_fields_3D(u, nx, ny, layers)
-  call wrap_fields_3D(v, nx, ny, layers)
-  call wrap_fields_3D(h, nx, ny, layers)
+    ! Wrap fields around for periodic simulations
+    call wrap_fields_3D(u, nx, ny, layers)
+    call wrap_fields_3D(v, nx, ny, layers)
+    call wrap_fields_3D(h, nx, ny, layers)
 
-  ! ------------------------- negative 1 time step --------------------------
-  ! Code to work out dhdtold, dudtold and dvdtold
+    ! ------------------------- negative 1 time step --------------------------
+    ! Code to work out dhdtold, dudtold and dvdtold
 
-  call state_derivative(dhdtold, dudtold, dvdtold, &
-      h, u, v, depth, &
-      dx, dy, wetmask, hfacW, hfacE, hfacN, hfacS, fu, fv, &
-      au, ar, botDrag, ah, slip, &
-      RedGrav, g_vec, rho0, wind_x, wind_y, &
-      spongeHTimeScale, spongeH, &
-      spongeUTimeScale, spongeU, &
-      spongeVTimeScale, spongeV, &
-      nx, ny, layers, n, debug_level)
+    call state_derivative(dhdtold, dudtold, dvdtold, &
+        h, u, v, depth, &
+        dx, dy, wetmask, hfacW, hfacE, hfacN, hfacS, fu, fv, &
+        au, ar, botDrag, ah, slip, &
+        RedGrav, g_vec, rho0, wind_x, wind_y, &
+        spongeHTimeScale, spongeH, &
+        spongeUTimeScale, spongeU, &
+        spongeVTimeScale, spongeV, &
+        nx, ny, layers, n, debug_level)
 
-  ! Calculate the values at half the time interval with Forward Euler
-  hhalf = h+0.5d0*dt*dhdtold
-  uhalf = u+0.5d0*dt*dudtold
-  vhalf = v+0.5d0*dt*dvdtold
+    ! Calculate the values at half the time interval with Forward Euler
+    hhalf = h+0.5d0*dt*dhdtold
+    uhalf = u+0.5d0*dt*dudtold
+    vhalf = v+0.5d0*dt*dvdtold
 
-  call state_derivative(dhdtold, dudtold, dvdtold, &
-      hhalf, uhalf, vhalf, depth, &
-      dx, dy, wetmask, hfacW, hfacE, hfacN, hfacS, fu, fv, &
-      au, ar, botDrag, ah, slip, &
-      RedGrav, g_vec, rho0, wind_x, wind_y, &
-      spongeHTimeScale, spongeH, &
-      spongeUTimeScale, spongeU, &
-      spongeVTimeScale, spongeV, &
-      nx, ny, layers, n, debug_level)
+    call state_derivative(dhdtold, dudtold, dvdtold, &
+        hhalf, uhalf, vhalf, depth, &
+        dx, dy, wetmask, hfacW, hfacE, hfacN, hfacS, fu, fv, &
+        au, ar, botDrag, ah, slip, &
+        RedGrav, g_vec, rho0, wind_x, wind_y, &
+        spongeHTimeScale, spongeH, &
+        spongeUTimeScale, spongeU, &
+        spongeVTimeScale, spongeV, &
+        nx, ny, layers, n, debug_level)
 
-  ! These are the values to be stored in the 'old' variables ready to start
-  ! the proper model run.
+    ! These are the values to be stored in the 'old' variables ready to start
+    ! the proper model run.
 
-  ! Calculate h, u, v with these tendencies
-  h = h + dt*dhdtold
-  u = u + dt*dudtold
-  v = v + dt*dvdtold
+    ! Calculate h, u, v with these tendencies
+    h = h + dt*dhdtold
+    u = u + dt*dudtold
+    v = v + dt*dvdtold
 
-  ! Apply the boundary conditions
-  call apply_boundary_conditions(u, hfacW, wetmask, nx, ny, layers)
-  call apply_boundary_conditions(v, hfacS, wetmask, nx, ny, layers)
+    ! Apply the boundary conditions
+    call apply_boundary_conditions(u, hfacW, wetmask, nx, ny, layers)
+    call apply_boundary_conditions(v, hfacS, wetmask, nx, ny, layers)
 
-  ! Wrap fields around for periodic simulations
-  call wrap_fields_3D(u, nx, ny, layers)
-  call wrap_fields_3D(v, nx, ny, layers)
-  call wrap_fields_3D(h, nx, ny, layers)
+    ! Wrap fields around for periodic simulations
+    call wrap_fields_3D(u, nx, ny, layers)
+    call wrap_fields_3D(v, nx, ny, layers)
+    call wrap_fields_3D(h, nx, ny, layers)
+
+  else if (niter0 .ne. 0) then
+    n = niter0
+
+    ! load in the state and derivative arrays
+    write(num, '(i10.10)') niter0
+
+    open(unit=10, form='unformatted', file='checkpoints/h.'//num)
+    read(10) h
+    close(10)
+    open(unit=10, form='unformatted', file='checkpoints/u.'//num)
+    read(10) u
+    close(10)
+    open(unit=10, form='unformatted', file='checkpoints/v.'//num)
+    read(10) v
+    close(10)
+
+    open(unit=10, form='unformatted', file='checkpoints/dhdt.'//num)
+    read(10) dhdt
+    close(10)
+    open(unit=10, form='unformatted', file='checkpoints/dudt.'//num)
+    read(10) dudt
+    close(10)
+    open(unit=10, form='unformatted', file='checkpoints/dvdt.'//num)
+    read(10) dvdt
+    close(10)
+
+    open(unit=10, form='unformatted', file='checkpoints/dhdtold.'//num)
+    read(10) dhdtold
+    close(10)
+    open(unit=10, form='unformatted', file='checkpoints/dudtold.'//num)
+    read(10) dudtold
+    close(10)
+    open(unit=10, form='unformatted', file='checkpoints/dvdtold.'//num)
+    read(10) dvdtold
+    close(10)
+
+    open(unit=10, form='unformatted', file='checkpoints/dhdtveryold.'//num)
+    read(10) dhdtveryold
+    close(10)
+    open(unit=10, form='unformatted', file='checkpoints/dudtveryold.'//num)
+    read(10) dudtveryold
+    close(10)
+    open(unit=10, form='unformatted', file='checkpoints/dvdtveryold.'//num)
+    read(10) dvdtveryold
+    close(10)
+
+
+    if (.not. RedGrav) then
+      open(unit=10, form='unformatted', file='checkpoints/eta.'//num)
+      read(10) eta
+      close(10)
+    end if
+  end if
 
   ! Now the model is ready to start.
   ! - We have h, u, v at the zeroth time step, and the tendencies at
@@ -608,10 +670,10 @@ subroutine model_run(h, u, v, eta, depth, dx, dy, wetmask, fu, fv, &
   !!! MAIN LOOP OF THE MODEL STARTS HERE                                  !!!
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-  do n = 1, nTimeSteps
+  do n = niter0+1, niter0+nTimeSteps
 
-    wind_x = base_wind_x*wind_mag_time_series(n)
-    wind_y = base_wind_y*wind_mag_time_series(n)
+    wind_x = base_wind_x*wind_mag_time_series(n-niter0)
+    wind_y = base_wind_y*wind_mag_time_series(n-niter0)
 
     call state_derivative(dhdt, dudt, dvdt, h, u, v, depth, &
         dx, dy, wetmask, hfacW, hfacE, hfacN, hfacS, fu, fv, &
@@ -689,7 +751,10 @@ subroutine model_run(h, u, v, eta, depth, dx, dy, wetmask, fu, fv, &
     ! Now have new fields in main arrays and old fields in very old arrays
 
     call maybe_dump_output(h, hav, u, uav, v, vav, eta, etaav, &
-        dudt, dvdt, dhdt, wind_x, wind_y, nx, ny, layers, &
+        dudt, dvdt, dhdt, &
+        dudtold, dvdtold, dhdtold, &
+        dudtveryold, dvdtveryold, dhdtveryold, &
+        wind_x, wind_y, nx, ny, layers, &
         n, nwrite, avwrite, checkpointwrite, &
         RedGrav, DumpWind, debug_level)
 
@@ -923,6 +988,8 @@ end subroutine barotropic_correction
 
 subroutine maybe_dump_output(h, hav, u, uav, v, vav, eta, etaav, &
         dudt, dvdt, dhdt, &
+        dudtold, dvdtold, dhdtold, &
+        dudtveryold, dvdtveryold, dhdtveryold, &
         wind_x, wind_y, nx, ny, layers, &
         n, nwrite, avwrite, checkpointwrite, &
         RedGrav, DumpWind, debug_level)
@@ -939,6 +1006,12 @@ subroutine maybe_dump_output(h, hav, u, uav, v, vav, eta, etaav, &
   double precision, intent(in)    :: dudt(0:nx+1, 0:ny+1, layers)
   double precision, intent(in)    :: dvdt(0:nx+1, 0:ny+1, layers)
   double precision, intent(in)    :: dhdt(0:nx+1, 0:ny+1, layers)
+  double precision, intent(in)    :: dudtold(0:nx+1, 0:ny+1, layers)
+  double precision, intent(in)    :: dvdtold(0:nx+1, 0:ny+1, layers)
+  double precision, intent(in)    :: dhdtold(0:nx+1, 0:ny+1, layers)
+  double precision, intent(in)    :: dudtveryold(0:nx+1, 0:ny+1, layers)
+  double precision, intent(in)    :: dvdtveryold(0:nx+1, 0:ny+1, layers)
+  double precision, intent(in)    :: dhdtveryold(0:nx+1, 0:ny+1, layers)
   double precision, intent(in)    :: wind_x(0:nx+1, 0:ny+1)
   double precision, intent(in)    :: wind_y(0:nx+1, 0:ny+1)
   integer,          intent(in)    :: nx, ny, layers, n
@@ -1041,20 +1114,36 @@ subroutine maybe_dump_output(h, hav, u, uav, v, vav, eta, etaav, &
   if (checkpointwrite .eq. 0) then
     ! not saving checkpoints, so move on
   else if (mod(n-1, checkpointwrite) .eq. 0) then
-    call write_output_3d(h, nx, ny, layers, 0, 0, &
+    call write_checkpoint_output(h, nx, ny, layers, &
     n, 'checkpoints/h.')
-    call write_output_3d(u, nx, ny, layers, 1, 0, &
+    call write_checkpoint_output(u, nx, ny, layers, &
     n, 'checkpoints/u.')
-    call write_output_3d(v, nx, ny, layers, 0, 1, &
+    call write_checkpoint_output(v, nx, ny, layers, &
     n, 'checkpoints/v.')
-    call write_output_3d(dhdt, nx, ny, layers, 0, 0, &
+
+    call write_checkpoint_output(dhdt, nx, ny, layers, &
       n, 'checkpoints/dhdt.')
-    call write_output_3d(dudt, nx, ny, layers, 1, 0, &
+    call write_checkpoint_output(dudt, nx, ny, layers, &
       n, 'checkpoints/dudt.')
-    call write_output_3d(dvdt, nx, ny, layers, 0, 1, &
+    call write_checkpoint_output(dvdt, nx, ny, layers, &
       n, 'checkpoints/dvdt.')
+
+    call write_checkpoint_output(dhdtold, nx, ny, layers, &
+      n, 'checkpoints/dhdtold.')
+    call write_checkpoint_output(dudtold, nx, ny, layers, &
+      n, 'checkpoints/dudtold.')
+    call write_checkpoint_output(dvdtold, nx, ny, layers, &
+      n, 'checkpoints/dvdtold.')
+
+    call write_checkpoint_output(dhdtveryold, nx, ny, layers, &
+      n, 'checkpoints/dhdtveryold.')
+    call write_checkpoint_output(dudtveryold, nx, ny, layers, &
+      n, 'checkpoints/dudtveryold.')
+    call write_checkpoint_output(dvdtveryold, nx, ny, layers, &
+      n, 'checkpoints/dvdtveryold.')
+
     if (.not. RedGrav) then
-      call write_output_2d(eta, nx, ny, 0, 0, &
+      call write_checkpoint_output(eta, nx, ny, 1, &
         n, 'checkpoints/eta.')
     end if
 
@@ -2378,6 +2467,31 @@ subroutine write_output_3d(array, nx, ny, layers, xstep, ystep, &
 
   return
 end subroutine write_output_3d
+
+!-----------------------------------------------------------------
+!> Write snapshot output of 3d field
+
+subroutine write_checkpoint_output(array, nx, ny, layers, &
+    n, name)
+  implicit none
+
+  double precision, intent(in) :: array(0:nx+1, 0:ny+1, layers)
+  integer,          intent(in) :: nx, ny, layers
+  integer,          intent(in) :: n
+  character(*),     intent(in) :: name
+
+  character(10)  :: num
+
+  write(num, '(i10.10)') n
+
+  ! Output the data to a file
+  open(unit=10, status='replace', file=name//num, &
+      form='unformatted')
+  write(10) array
+  close(10)
+
+  return
+end subroutine write_checkpoint_output
 
 !-----------------------------------------------------------------
 !> Write snapshot output of 2d field

--- a/aronnax.f90
+++ b/aronnax.f90
@@ -767,13 +767,13 @@ subroutine state_derivative(dhdt, dudt, dvdt, h, u, v, depth, &
     call evaluate_b_RedGrav(b, h, u, v, nx, ny, layers, g_vec)
     if (debug_level .ge. 4) then
       call write_output_3d(b, nx, ny, layers, 0, 0, &
-        n, 'snap.BP.')
+        n, 'output/snap.BP.')
     end if
   else
     call evaluate_b_iso(b, h, u, v, nx, ny, layers, g_vec, depth)
     if (debug_level .ge. 4) then
       call write_output_3d(b, nx, ny, layers, 0, 0, &
-        n, 'snap.BP.')
+        n, 'output/snap.BP.')
     end if
   end if
 
@@ -781,7 +781,7 @@ subroutine state_derivative(dhdt, dudt, dvdt, h, u, v, depth, &
   call evaluate_zeta(zeta, u, v, nx, ny, layers, dx, dy)
   if (debug_level .ge. 4) then
     call write_output_3d(zeta, nx, ny, layers, 1, 1, &
-      n, 'snap.zeta.')
+      n, 'output/snap.zeta.')
   end if
 
   ! Calculate dhdt, dudt, dvdt at current time step
@@ -870,7 +870,7 @@ subroutine barotropic_correction(hnew, unew, vnew, eta, etanew, depth, a, &
   ! print *, maxval(abs(etastar))
   if (debug_level .ge. 4) then
     call write_output_2d(etastar, nx, ny, 0, 0, &
-      n, 'snap.eta_star.')
+      n, 'output/snap.eta_star.')
   end if
 
   ! Prevent barotropic signals from bouncing around outside the
@@ -890,7 +890,7 @@ subroutine barotropic_correction(hnew, unew, vnew, eta, etanew, depth, a, &
 
   if (debug_level .ge. 4) then
     call write_output_2d(etanew, nx, ny, 0, 0, &
-      n, 'snap.eta_new.')
+      n, 'output/snap.eta_new.')
   end if
 
   etanew = etanew*wetmask
@@ -960,32 +960,32 @@ subroutine maybe_dump_output(h, hav, u, uav, v, vav, eta, etaav, &
   if (dump_output) then 
     
     call write_output_3d(h, nx, ny, layers, 0, 0, &
-    n, 'snap.h.')
+    n, 'output/snap.h.')
     call write_output_3d(u, nx, ny, layers, 1, 0, &
-    n, 'snap.u.')
+    n, 'output/snap.u.')
     call write_output_3d(v, nx, ny, layers, 0, 1, &
-    n, 'snap.v.')
+    n, 'output/snap.v.')
 
 
     if (.not. RedGrav) then
       call write_output_2d(eta, nx, ny, 0, 0, &
-        n, 'snap.eta.')
+        n, 'output/snap.eta.')
     end if
 
     if (DumpWind .eqv. .true.) then
       call write_output_2d(wind_x, nx, ny, 1, 0, &
-        n, 'wind_x.')
+        n, 'output/wind_x.')
       call write_output_2d(wind_y, nx, ny, 0, 1, &
-        n, 'wind_y.')
+        n, 'output/wind_y.')
     end if
 
     if (debug_level .ge. 1) then
       call write_output_3d(dhdt, nx, ny, layers, 0, 0, &
-        n, 'debug.dhdt.')
+        n, 'output/debug.dhdt.')
       call write_output_3d(dudt, nx, ny, layers, 1, 0, &
-        n, 'debug.dudt.')
+        n, 'output/debug.dudt.')
       call write_output_3d(dvdt, nx, ny, layers, 0, 1, &
-        n, 'debug.dvdt.')
+        n, 'output/debug.dvdt.')
     end if
 
     ! Check if there are NaNs in the data
@@ -1008,16 +1008,16 @@ subroutine maybe_dump_output(h, hav, u, uav, v, vav, eta, etaav, &
     end if
 
     call write_output_3d(hav, nx, ny, layers, 0, 0, &
-    n, 'av.h.')
+    n, 'output/av.h.')
     call write_output_3d(uav, nx, ny, layers, 1, 0, &
-    n, 'av.u.')
+    n, 'output/av.u.')
     call write_output_3d(vav, nx, ny, layers, 0, 1, &
-    n, 'av.v.')
+    n, 'output/av.v.')
 
 
     if (.not. RedGrav) then
       call write_output_2d(etaav, nx, ny, 0, 0, &
-        n, 'av.eta.')
+        n, 'output/av.eta.')
     end if
 
     ! Check if there are NaNs in the data
@@ -1035,6 +1035,8 @@ subroutine maybe_dump_output(h, hav, u, uav, v, vav, eta, etaav, &
     ! h2av = 0.0
 
   end if
+
+
 
   return
 end subroutine maybe_dump_output
@@ -2347,7 +2349,7 @@ subroutine write_output_3d(array, nx, ny, layers, xstep, ystep, &
   write(num, '(i10.10)') n
 
   ! Output the data to a file
-  open(unit=10, status='replace', file='output/'//name//num, &
+  open(unit=10, status='replace', file=name//num, &
       form='unformatted')
   write(10) array(1:nx+xstep, 1:ny+ystep, :)
   close(10)
@@ -2372,7 +2374,7 @@ subroutine write_output_2d(array, nx, ny, xstep, ystep, &
   write(num, '(i10.10)') n
 
   ! Output the data to a file
-  open(unit=10, status='replace', file='output/'//name//num, &
+  open(unit=10, status='replace', file=name//num, &
       form='unformatted')
   write(10) array(1:nx+xstep, 1:ny+ystep)
   close(10)

--- a/aronnax/driver.py
+++ b/aronnax/driver.py
@@ -61,6 +61,7 @@ def simulate(work_dir=".", config_path="aronnax.conf", **options):
             config.write(f)
         sub.check_call(["rm", "-rf", "output/"])
         sub.check_call(["mkdir", "-p", "output/"])
+        sub.check_call(["mkdir", "-p", "checkpoints/"])
         with working_directory("input"):
             generate_input_data_files(config)
         generate_parameters_file(config)

--- a/aronnax/driver.py
+++ b/aronnax/driver.py
@@ -59,7 +59,7 @@ def simulate(work_dir=".", config_path="aronnax.conf", **options):
         # XXX Try to avoid overwriting the input configuration
         with open('aronnax-merged.conf', 'w') as f:
             config.write(f)
-        sub.check_call(["rm", "-rf", "output/"])
+        # sub.check_call(["rm", "-rf", "output/"])
         sub.check_call(["mkdir", "-p", "output/"])
         sub.check_call(["mkdir", "-p", "checkpoints/"])
         with working_directory("input"):

--- a/aronnax/driver.py
+++ b/aronnax/driver.py
@@ -98,6 +98,7 @@ section_map = {
     "nTimeSteps"           : "numerics",
     "dumpFreq"             : "numerics",
     "avFreq"               : "numerics",
+    "checkpointFreq"       : "numerics",
     "hmin"                 : "numerics",
     "maxits"               : "numerics",
     "eps"                  : "numerics",

--- a/aronnax/driver.py
+++ b/aronnax/driver.py
@@ -95,6 +95,7 @@ section_map = {
     "botDrag"              : "numerics",
     "dt"                   : "numerics",
     "slip"                 : "numerics",
+    "niter0"               : "numerics",
     "nTimeSteps"           : "numerics",
     "dumpFreq"             : "numerics",
     "avFreq"               : "numerics",

--- a/docs/running_aronnax.rst
+++ b/docs/running_aronnax.rst
@@ -46,6 +46,10 @@ This parameter determines whether the model produces additional outputs. It shou
  - 4: dump all of the above fields every time step (mostly implemented)
  - 5: dump everything every time step including the two initial RK4 steps (not implemented)
 
+niter0
+------
+This parameter allows a simulation to be restarted from the given timestep. It requires that the appropriate files are in the 'checkpoints' directory. All parameters, except for the number of grid points in the domain, may be altered when restarting a simulation. This is intended for breaking long simulations into shorter, more manageable chunks, and for running perturbation experiments. 
+
 wetMaskFile
 -----------
 The wetmask defines which grid points within the computational domain contain fluid. The wetmask is defined on the tracer points, and a value of 1 defines fluid, while a value of 0 defines land. The domain is doubly periodic in `x` and `y` by default. To produce a closed domain the wetmaks should be set to 0 along the edges of the domain. To close the domain it is sufficient to place a strip of land along either the northern or southern boundary and either the western or eastern boundary. You may find it conceptually easier to close both edges.

--- a/docs/running_aronnax.rst
+++ b/docs/running_aronnax.rst
@@ -19,9 +19,6 @@ As described above, it is possible to define functions that can be passed to `ar
           drv.simulate(zonalWindFile=[wind],
                        nx=10, ny=10, exe="aronnax_test", dx=xlen/10, dy=ylen/10)
 
-.. warning::
-    Running Aronnax in a directory that contains outputs from a previous simulation will result in those outputs being overwritten. The model does not currently check if the  output directory is empty.
-
 
 Parameters
 ===========

--- a/test/beta_plane_bump/aronnax.conf
+++ b/test/beta_plane_bump/aronnax.conf
@@ -25,6 +25,7 @@ slip = 0.0
 nTimeSteps = 502
 dumpFreq = 1.2e5
 avFreq = 1.2e5
+checkpointFreq = 1.2e5
 hmin = 100
 maxits = 1000
 eps = 1e-2

--- a/test/beta_plane_bump_red_grav/aronnax.conf
+++ b/test/beta_plane_bump_red_grav/aronnax.conf
@@ -24,6 +24,7 @@ slip = 0.0
 nTimeSteps = 502
 dumpFreq = 6e4
 avFreq = 3e5
+checkpointFreq = 3e5
 hmin = 100
 maxits = 1000
 eps = 1e-2

--- a/test/output_preservation_test.py
+++ b/test/output_preservation_test.py
@@ -116,6 +116,17 @@ def test_gaussian_bump():
         assert_outputs_close(10, 10, 2, 2e-13)
         assert_volume_conservation(10, 10, 2, 1e-5)
 
+def test_gaussian_bump_continuation():
+    xlen = 1e6
+    ylen = 1e6
+    with working_directory(p.join(self_path, "beta_plane_bump")):
+        drv.simulate(initHfile=[bump, lambda X, Y: 2000. - bump(X, Y)],
+                     nx=10, ny=10, exe=test_executable, 
+                     dx=xlen/10, dy=ylen/10,
+                     niter0=401)
+        # assert_outputs_close(10, 10, 2, 2e-13)
+        # assert_volume_conservation(10, 10, 2, 1e-5)
+
 def test_gaussian_bump_debug_test():
     xlen = 1e6
     ylen = 1e6

--- a/test/output_preservation_test.py
+++ b/test/output_preservation_test.py
@@ -123,9 +123,9 @@ def test_gaussian_bump_continuation():
         drv.simulate(initHfile=[bump, lambda X, Y: 2000. - bump(X, Y)],
                      nx=10, ny=10, exe=test_executable, 
                      dx=xlen/10, dy=ylen/10,
-                     niter0=401)
-        # assert_outputs_close(10, 10, 2, 2e-13)
-        # assert_volume_conservation(10, 10, 2, 1e-5)
+                     niter0=201, nTimeSteps=200)
+        assert_outputs_close(10, 10, 2, 2e-13)
+        assert_volume_conservation(10, 10, 2, 1e-5)
 
 def test_gaussian_bump_debug_test():
     xlen = 1e6


### PR DESCRIPTION
This PR implements a restart feature - given the appropriate checkpoint files and value for `niter0` the model will continue with a simulation.

There is no requirement that parameters, apart from domain size, remain consistent between runs. The restarted simulation takes in parameters in exactly the same way as a normal run - i.e. through the call to `driver.simulate` or the `aronnax.conf` file.

Other small changes:
- the output directory is no longer wiped clean when starting a simulation (since restarting in a directory shouldn't delete data)
- checkpoint files are dumped at the end of every simulation, as discussed in #118 
- the write_output_` subroutines now have to be told which folder to write into (this change wasn't needed in the end, but seems like a better default so I left it)