### PR TITLE
Fix underflow error and add more compiler flags to test executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,13 @@ aronnax_core: aronnax.f90 Makefile
 	mpif90 -g -Ofast -fno-stack-arrays $< -o $@ -cpp
 
 aronnax_test: aronnax.f90 Makefile
-	mpif90 -g -fprofile-arcs -ftest-coverage -O1 -fcheck=all $< -o $@ -cpp
+	mpif90 -g -fprofile-arcs -ftest-coverage -O1 -fcheck=all -ffpe-trap=invalid,zero,overflow,underflow -Wuninitialized $< -o $@ -cpp
 
 aronnax_prof: aronnax.f90 Makefile
 	mpif90 -g -pg -Ofast $< -o $@ -cpp
 
 aronnax_external_solver_test: aronnax.f90 Makefile
-	mpif90 -g -fprofile-arcs -ftest-coverage -O1 $< -o $@ -cpp -DuseExtSolver $(LIBS)
+	mpif90 -g -fprofile-arcs -ftest-coverage -O1 -ffpe-trap=invalid,zero,overflow,underflow -fcheck=all -Wuninitialized $< -o $@ -cpp -DuseExtSolver $(LIBS)
 
 aronnax_external_solver: aronnax.f90 Makefile
 	mpif90 -g -Ofast -fno-stack-arrays $< -o $@ -cpp -DuseExtSolver $(LIBS)

--- a/aronnax.f90
+++ b/aronnax.f90
@@ -146,7 +146,10 @@ program aronnax
       DumpWind, wind_mag_time_series_file
 
   ! Set default values here
-  diagFreq = 0
+  dumpFreq = 0d0
+  avFreq = 0d0
+  checkpointFreq = 0d0
+  diagFreq = 0d0
   debug_level = 0
   niter0 = 0
   RelativeWind = .FALSE.


### PR DESCRIPTION
As identified in #168 some runs produced a warning about underflow when they finished. Using a compiler flag to capture these floating point errors caused 7 of the tests to fail.

This PR stops those tests from failing by initialising the output frequencies to zero before the namelists are read. This means that user specified values will over ride the default zeros.

The `-Wuninitialized` flag was alse added to the test compilation as well.