### PR TITLE
Add vertical diffusion

### DIFF
--- a/aronnax.conf
+++ b/aronnax.conf
@@ -2,7 +2,7 @@
 
 #------------------------------------------------------------------------------
 # au is the lateral friction coefficient in m^2 / s
-# ah is thickness diffusivity in m^2 / s
+# kh is thickness diffusivity in m^2 / s
 # ar is linear drag between layers in 1/s
 # dt is time step in seconds
 # slip is free-slip (=0), no-slip (=1), or partial slip (something in between)
@@ -32,7 +32,7 @@
 
 [numerics]
 au = 500.
-ah = 0.0
+kh = 0.0
 ar = 0.0
 dt = 600.
 slip = 0.0

--- a/aronnax.conf
+++ b/aronnax.conf
@@ -2,8 +2,9 @@
 
 #------------------------------------------------------------------------------
 # au is the lateral friction coefficient in m^2 / s
-# kh is thickness diffusivity in m^2 / s
 # ar is linear drag between layers in 1/s
+# kh is thickness diffusivity in m^2 / s
+# kv is vertical thickness diffusivity in m^2/s
 # dt is time step in seconds
 # slip is free-slip (=0), no-slip (=1), or partial slip (something in between)
 # niter0: the timestep at which the simulation begins. If not zero, then there 
@@ -32,8 +33,9 @@
 
 [numerics]
 au = 500.
-kh = 0.0
 ar = 0.0
+kh = 0.0
+kv = 0.0
 dt = 600.
 slip = 0.0
 niter0 = 0

--- a/aronnax/driver.py
+++ b/aronnax/driver.py
@@ -90,8 +90,9 @@ sections = ["executable", "numerics", "model", "pressure_solver", "sponge",
 
 section_map = {
     "au"                   : "numerics",
-    "kh"                   : "numerics",
     "ar"                   : "numerics",
+    "kh"                   : "numerics",
+    "kv"                   : "numerics",
     "botDrag"              : "numerics",
     "dt"                   : "numerics",
     "slip"                 : "numerics",

--- a/aronnax/driver.py
+++ b/aronnax/driver.py
@@ -90,7 +90,7 @@ sections = ["executable", "numerics", "model", "pressure_solver", "sponge",
 
 section_map = {
     "au"                   : "numerics",
-    "ah"                   : "numerics",
+    "kh"                   : "numerics",
     "ar"                   : "numerics",
     "botDrag"              : "numerics",
     "dt"                   : "numerics",

--- a/benchmarks/beta_plane_bump/aronnax.conf
+++ b/benchmarks/beta_plane_bump/aronnax.conf
@@ -1,7 +1,7 @@
 # Aronnax configuration file. Change the values, but not the names.
 # 
 # au is viscosity
-# ah is thickness diffusivity
+# kh is thickness diffusivity
 # ar is linear drag between layers
 # dt is time step
 # slip is free-slip (=0), no-slip (=1), or partial slip (something in between)
@@ -17,7 +17,7 @@
 
 [numerics]
 au = 500.
-ah = 0.0
+kh = 0.0
 ar = 0.0
 botDrag = 1e-6
 dt = 600.

--- a/benchmarks/beta_plane_bump_red_grav/aronnax.conf
+++ b/benchmarks/beta_plane_bump_red_grav/aronnax.conf
@@ -1,7 +1,7 @@
 # Aronnax configuration file. Change the values, but not the names.
 # 
 # au is viscosity
-# ah is thickness diffusivity
+# kh is thickness diffusivity
 # ar is linear drag between layers
 # dt is time step
 # slip is free-slip (=0), no-slip (=1), or partial slip (something in between)
@@ -17,7 +17,7 @@
 
 [numerics]
 au = 500.
-ah = 0.0
+kh = 0.0
 ar = 1e-8
 dt = 600.
 slip = 0.0

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -5,6 +5,8 @@ Development
 Since latest release
 --------------------
 
+Add vertical diffusion of mass between layers (2 March 2018)
+
 
 Version 0.1.0 (11 December 2017)
 --------------------------------

--- a/examples/n_layer/beta_plane_bump/aronnax.conf
+++ b/examples/n_layer/beta_plane_bump/aronnax.conf
@@ -1,7 +1,7 @@
 # Aronnax configuration file. Change the values, but not the names.
 # 
 # au is viscosity
-# ah is thickness diffusivity
+# kh is thickness diffusivity
 # ar is linear drag between layers
 # dt is time step
 # slip is free-slip (=0), no-slip (=1), or partial slip (something in between)
@@ -17,7 +17,7 @@
 
 [numerics]
 au = 100.
-ah = 0.0
+kh = 0.0
 ar = 0.0
 botDrag = 1e-6
 dt = 600.

--- a/examples/n_layer/beta_plane_gyre/aronnax.conf
+++ b/examples/n_layer/beta_plane_gyre/aronnax.conf
@@ -1,7 +1,7 @@
 # Aronnax configuration file. Change the values, but not the names.
 # 
 # au is viscosity
-# ah is thickness diffusivity
+# kh is thickness diffusivity
 # ar is linear drag between layers
 # dt is time step
 # slip is free-slip (=0), no-slip (=1), or partial slip (something in between)
@@ -17,7 +17,7 @@
 
 [numerics]
 au = 100.
-ah = 0., 0.
+kh = 0., 0.
 ar = 1e-8
 botDrag = 1e-6
 dt = 600.

--- a/examples/reduced_gravity/beta_plane_bump/aronnax.conf
+++ b/examples/reduced_gravity/beta_plane_bump/aronnax.conf
@@ -1,7 +1,7 @@
 # Aronnax configuration file. Change the values, but not the names.
 #
 # au is viscosity
-# ah is thickness diffusivity
+# kh is thickness diffusivity
 # ar is linear drag between layers
 # dt is time step
 # slip is free-slip (=0), no-slip (=1), or partial slip (something in between)
@@ -17,7 +17,7 @@
 
 [numerics]
 au = 100.
-ah = 0.0
+kh = 0.0
 ar = 1e-8
 dt = 600.
 slip = 0.0

--- a/examples/reduced_gravity/beta_plane_gyre/aronnax.conf
+++ b/examples/reduced_gravity/beta_plane_gyre/aronnax.conf
@@ -1,7 +1,7 @@
 # Parameter file. Change the values, but not the names.
 # 
 # au is viscosity
-# ah is thickness diffusivity
+# kh is thickness diffusivity
 # ar is linear drag between layers
 # dt is time step
 # slip is free-slip (=0), no-slip (=1), or partial slip (something in between)
@@ -17,7 +17,7 @@
 
 [numerics]
 au = 100.
-ah = 0.0
+kh = 0.0
 ar = 1e-8
 dt = 600.
 slip = 1.0

--- a/reproductions/Davis_et_al_2014/control/aronnax.conf
+++ b/reproductions/Davis_et_al_2014/control/aronnax.conf
@@ -1,7 +1,7 @@
 # Aronnax configuration file. Change the values, but not the names.
 # 
 # au is viscosity
-# ah is thickness diffusivity
+# kh is thickness diffusivity
 # ar is linear drag between layers
 # dt is time step
 # slip is free-slip (=0), no-slip (=1), or partial slip (something in between)
@@ -17,7 +17,7 @@
 
 [numerics]
 au = 150.
-ah = 1300
+kh = 1300
 ar = 0
 dt = 1000.
 slip = 1.0

--- a/reproductions/Davis_et_al_2014/control_final_five/aronnax.conf
+++ b/reproductions/Davis_et_al_2014/control_final_five/aronnax.conf
@@ -1,7 +1,7 @@
 # Aronnax configuration file. Change the values, but not the names.
 # 
 # au is viscosity
-# ah is thickness diffusivity
+# kh is thickness diffusivity
 # ar is linear drag between layers
 # dt is time step
 # slip is free-slip (=0), no-slip (=1), or partial slip (something in between)
@@ -17,7 +17,7 @@
 
 [numerics]
 au = 150.
-ah = 1300.
+kh = 1300.
 ar = 0
 dt = 1000.
 slip = 1.

--- a/test/beta_plane_bump/aronnax.conf
+++ b/test/beta_plane_bump/aronnax.conf
@@ -1,7 +1,7 @@
 # Aronnax configuration file. Change the values, but not the names.
 # 
 # au is viscosity
-# ah is thickness diffusivity
+# kh is thickness diffusivity
 # ar is linear drag between layers
 # dt is time step
 # slip is free-slip (=0), no-slip (=1), or partial slip (something in between)
@@ -17,7 +17,7 @@
 
 [numerics]
 au = 500.
-ah = 0.0
+kh = 0.0
 ar = 0.0
 botDrag = 1e-6
 dt = 600.

--- a/test/beta_plane_bump_debug_test/aronnax.conf
+++ b/test/beta_plane_bump_debug_test/aronnax.conf
@@ -1,7 +1,7 @@
 # Aronnax configuration file. Change the values, but not the names.
 # 
 # au is viscosity
-# ah is thickness diffusivity
+# kh is thickness diffusivity
 # ar is linear drag between layers
 # dt is time step
 # slip is free-slip (=0), no-slip (=1), or partial slip (something in between)
@@ -17,7 +17,7 @@
 
 [numerics]
 au = 500.
-ah = 0.0
+kh = 0.0
 ar = 0.0
 botDrag = 1e-6
 dt = 600.

--- a/test/beta_plane_bump_red_grav/aronnax.conf
+++ b/test/beta_plane_bump_red_grav/aronnax.conf
@@ -1,7 +1,7 @@
 # Aronnax configuration file. Change the values, but not the names.
 #
 # au is viscosity
-# ah is thickness diffusivity
+# kh is thickness diffusivity
 # ar is linear drag between layers
 # dt is time step
 # slip is free-slip (=0), no-slip (=1), or partial slip (something in between)
@@ -17,7 +17,7 @@
 
 [numerics]
 au = 500.
-ah = 0.0
+kh = 0.0
 ar = 1e-8
 dt = 600.
 slip = 0.0

--- a/test/beta_plane_gyre/aronnax.conf
+++ b/test/beta_plane_gyre/aronnax.conf
@@ -1,7 +1,7 @@
 # Aronnax configuration file. Change the values, but not the names.
 # 
 # au is viscosity
-# ah is thickness diffusivity
+# kh is thickness diffusivity
 # ar is linear drag between layers
 # dt is time step
 # slip is free-slip (=0), no-slip (=1), or partial slip (something in between)
@@ -17,7 +17,7 @@
 
 [numerics]
 au = 500.
-ah = 500.0,500.
+kh = 500.0,500.
 ar = 1e-8
 botDrag = 1e-6
 dt = 600.

--- a/test/beta_plane_gyre_free_surf/aronnax.conf
+++ b/test/beta_plane_gyre_free_surf/aronnax.conf
@@ -1,7 +1,7 @@
 # Aronnax configuration file. Change the values, but not the names.
 # 
 # au is viscosity
-# ah is thickness diffusivity
+# kh is thickness diffusivity
 # ar is linear drag between layers
 # dt is time step
 # slip is free-slip (=0), no-slip (=1), or partial slip (something in between)
@@ -17,7 +17,7 @@
 
 [numerics]
 au = 500.
-ah = 500.0,500.
+kh = 500.0,500.
 ar = 1e-8
 botDrag = 1e-6
 dt = 600.

--- a/test/beta_plane_gyre_red_grav/aronnax.conf
+++ b/test/beta_plane_gyre_red_grav/aronnax.conf
@@ -1,7 +1,7 @@
 # Parameter file. Change the values, but not the names.
 # 
 # au is viscosity
-# ah is thickness diffusivity
+# kh is thickness diffusivity
 # ar is linear drag between layers
 # dt is time step
 # slip is free-slip (=0), no-slip (=1), or partial slip (something in between)
@@ -17,7 +17,7 @@
 
 [numerics]
 au = 500.
-ah = 0.0
+kh = 0.0
 ar = 1e-8
 dt = 600.
 slip = 1.0

--- a/test/f_plane/aronnax.conf
+++ b/test/f_plane/aronnax.conf
@@ -1,7 +1,7 @@
 # Aronnax configuration file. Change the values, but not the names.
 # 
 # au is viscosity
-# ah is thickness diffusivity
+# kh is thickness diffusivity
 # ar is linear drag between layers
 # dt is time step
 # slip is free-slip (=0), no-slip (=1), or partial slip (something in between)
@@ -17,7 +17,7 @@
 
 [numerics]
 au = 500.
-ah = 0.0
+kh = 0.0
 ar = 1e-8
 botDrag = 1e-6
 dt = 100.

--- a/test/f_plane_red_grav/aronnax.conf
+++ b/test/f_plane_red_grav/aronnax.conf
@@ -1,7 +1,7 @@
 # Aronnax configuration file. Change the values, but not the names.
 # 
 # au is viscosity
-# ah is thickness diffusivity
+# kh is thickness diffusivity
 # ar is linear drag between layers
 # dt is time step
 # slip is free-slip (=0), no-slip (=1), or partial slip (something in between)
@@ -17,7 +17,7 @@
 
 [numerics]
 au = 500.
-ah = 0.0
+kh = 0.0
 ar = 1e-8
 dt = 600.
 slip = 0.0

--- a/test/output_preservation_test.py
+++ b/test/output_preservation_test.py
@@ -362,7 +362,7 @@ def test_vertical_thickness_diffusion():
         assert np.max(abs(simuated_h_evo[:,1] - expected_h_evo)) < 0.0005
 
 
-def test_vertical_thickness_diffusion_3_layers():
+def test_vertical_thickness_diffusion_Hypre_3_layers():
     nx = 2
     ny = 2
     layers = 3

--- a/test/periodic_BC/aronnax.conf
+++ b/test/periodic_BC/aronnax.conf
@@ -1,7 +1,7 @@
 # Aronnax configuration file. Change the values, but not the names.
 # 
 # au is viscosity
-# ah is thickness diffusivity
+# kh is thickness diffusivity
 # ar is linear drag between layers
 # dt is time step
 # slip is free-slip (=0), no-slip (=1), or partial slip (something in between)
@@ -17,7 +17,7 @@
 
 [numerics]
 au = 500.
-ah = 0.,0.
+kh = 0.,0.
 ar = 1e-8
 botDrag = 1e-4
 dt = 100.

--- a/test/periodic_BC_red_grav/aronnax.conf
+++ b/test/periodic_BC_red_grav/aronnax.conf
@@ -1,7 +1,7 @@
 # Aronnax configuration file. Change the values, but not the names.
 # 
 # au is viscosity
-# ah is thickness diffusivity
+# kh is thickness diffusivity
 # ar is linear drag between layers
 # dt is time step
 # slip is free-slip (=0), no-slip (=1), or partial slip (something in between)
@@ -17,7 +17,7 @@
 
 [numerics]
 au = 500.
-ah = 0.,0.
+kh = 0.,0.
 ar = 1e-8
 botDrag = 1e-6
 dt = 100.

--- a/test/physics_tests/f_plane_n_layer_init_u/aronnax.conf
+++ b/test/physics_tests/f_plane_n_layer_init_u/aronnax.conf
@@ -1,7 +1,7 @@
 # Aronnax configuration file. Change the values, but not the names.
 # 
 # au is viscosity
-# ah is thickness diffusivity
+# kh is thickness diffusivity
 # ar is linear drag between layers
 # dt is time step
 # slip is free-slip (=0), no-slip (=1), or partial slip (something in between)
@@ -17,7 +17,7 @@
 
 [numerics]
 au = 0.
-ah = 0.0
+kh = 0.0
 ar = 0e-8
 botDrag = 0e-6
 dt = 100.

--- a/test/physics_tests/f_plane_n_layer_wind/aronnax.conf
+++ b/test/physics_tests/f_plane_n_layer_wind/aronnax.conf
@@ -1,7 +1,7 @@
 # Aronnax configuration file. Change the values, but not the names.
 # 
 # au is viscosity
-# ah is thickness diffusivity
+# kh is thickness diffusivity
 # ar is linear drag between layers
 # dt is time step
 # slip is free-slip (=0), no-slip (=1), or partial slip (something in between)
@@ -17,7 +17,7 @@
 
 [numerics]
 au = 0.
-ah = 0.0
+kh = 0.0
 ar = 0e-8
 botDrag = 0e-6
 dt = 100.

--- a/test/physics_tests/f_plane_red_grav_init_u/aronnax.conf
+++ b/test/physics_tests/f_plane_red_grav_init_u/aronnax.conf
@@ -1,7 +1,7 @@
 # Aronnax configuration file. Change the values, but not the names.
 # 
 # au is viscosity
-# ah is thickness diffusivity
+# kh is thickness diffusivity
 # ar is linear drag between layers
 # dt is time step
 # slip is free-slip (=0), no-slip (=1), or partial slip (something in between)
@@ -17,7 +17,7 @@
 
 [numerics]
 au = 0.
-ah = 0.0
+kh = 0.0
 ar = 0e-8
 botDrag = 0e-6
 dt = 100.

--- a/test/physics_tests/f_plane_red_grav_wind/aronnax.conf
+++ b/test/physics_tests/f_plane_red_grav_wind/aronnax.conf
@@ -1,7 +1,7 @@
 # Aronnax configuration file. Change the values, but not the names.
 # 
 # au is viscosity
-# ah is thickness diffusivity
+# kh is thickness diffusivity
 # ar is linear drag between layers
 # dt is time step
 # slip is free-slip (=0), no-slip (=1), or partial slip (something in between)
@@ -17,7 +17,7 @@
 
 [numerics]
 au = 0.
-ah = 0.0
+kh = 0.0
 ar = 0e-8
 botDrag = 0e-6
 dt = 100.

--- a/test/relative_wind/aronnax.conf
+++ b/test/relative_wind/aronnax.conf
@@ -1,7 +1,7 @@
 # Aronnax configuration file. Change the values, but not the names.
 # 
 # au is viscosity
-# ah is thickness diffusivity
+# kh is thickness diffusivity
 # ar is linear drag between layers
 # dt is time step
 # slip is free-slip (=0), no-slip (=1), or partial slip (something in between)
@@ -17,7 +17,7 @@
 
 [numerics]
 au = 0.
-ah = 0.
+kh = 0.
 ar = 0
 botDrag = 0
 dt = 50.

--- a/test/vertical_diffusion/aronnax.conf
+++ b/test/vertical_diffusion/aronnax.conf
@@ -1,0 +1,61 @@
+# Aronnax configuration file. Change the values, but not the names.
+# 
+# au is viscosity
+# kh is thickness diffusivity
+# kv is vertical thickness diffusivity
+# ar is linear drag between layers
+# dt is time step
+# slip is free-slip (=0), no-slip (=1), or partial slip (something in between)
+# nTimeSteps: number of timesteps before stopping
+# dumpFreq: frequency of snapshot output
+# avFreq: frequency of averaged output
+# hmin: minimum layer thickness allowed by model (for stability)
+# maxits: maximum iterations for the successive over relaxation algorithm. Should be at least max(nx,ny), and probably nx*ny
+# eps: convergence tolerance for SOR solver
+# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid. So far all tests using freesurfFac = 1. have failed 
+# g is the gravity at interfaces (including surface). must have as many entries as there are layers
+# input files are where to look for the various inputs
+
+[numerics]
+au = 0.
+ar = 0
+kh = 0.
+kv = 0.
+botDrag = 0
+dt = 100.
+slip = 0.0
+nTimeSteps = 315360
+# daily
+dumpFreq = 0
+avFreq = 0
+checkpointFreq = 0
+diagFreq = 86400
+hmin = 10
+maxits = 1000
+eps = 1e-2
+freesurfFac = 0.
+thickness_error = 1e-2
+
+[pressure_solver]
+nProcX = 1
+nProcY = 1
+
+[model]
+RedGrav = yes
+
+[physics]
+g_vec = 6.22e-2
+rho0 = 1030.
+
+[grid]
+layers = 1
+fUfile = :f_plane_f_u:14.e-5
+fVfile = :f_plane_f_v:14.e-5
+
+# Inital conditions for h
+[initial_conditions]
+
+[external_forcing]
+DumpWind = no
+RelativeWind = yes
+Cd = 5.5e-3


### PR DESCRIPTION
This PR implements a naive diffusive mass flux between layers, as discussed in #175. For most simulations the diffusion coefficient, `kv`, will be set to zero.

It also streamlines the names of the diffusive and viscous parameters, closing #176.

The new functionality is tested in two simulations:
- a 1.5 layer simulation in which the simulated layer thickness is compared to an analytical expectation; and
- a 3 layer simulation in which the thickness of the top and bottom layers is compared, to ensure that they grow at the same rate.


