### PR TITLE
Add an upwind advection scheme

### DIFF
--- a/aronnax.conf
+++ b/aronnax.conf
@@ -30,6 +30,10 @@
 #   at the frequency controlled by dumpFreq and avFreq. Specifying larger
 #   integer values results in progressively more output more frequently. See
 #   the documentation for details.
+# hAdvecScheme selects which advection scheme to use when advecting the
+#   thickness field. Current options are:
+#   1 first-order centered differencing
+#   2 first-order upwind differencing
 
 [numerics]
 au = 500.
@@ -51,6 +55,7 @@ freesurfFac = 0.
 botDrag = 1e-6
 thickness_error = 1e-2
 debug_level = 0
+hAdvecScheme = 2
 #------------------------------------------------------------------------------
 
 # RedGrav selects whether to use n+1/2 layer physics (RedGrav=yes), or n-layer 

--- a/aronnax/driver.py
+++ b/aronnax/driver.py
@@ -108,6 +108,7 @@ section_map = {
     "freesurfFac"          : "numerics",
     "thickness_error"      : "numerics",
     "debug_level"          : "numerics",
+    "hAdvecScheme"         : "numerics",
     "hmean"                : "model",
     "depthFile"            : "model",
     "H0"                   : "model",

--- a/docs/running_aronnax.rst
+++ b/docs/running_aronnax.rst
@@ -87,3 +87,10 @@ The wetmask defines which grid points within the computational domain contain fl
 RelativeWind
 ------------
 If this is false, then the wind input file is given in N m\ :sup:`--2`. If true, then the wind input file is in m s\ :sup:`--1` and a quadratic drag law is used to accelerate the fluid with `Cd` as the quadratic drag coefficient. 
+
+hAdvecScheme
+------------
+`hAdvecScheme` is an integer that selects the advection scheme used for thickness in the continuity equation. Currently two options are implemented:
+
+- `hAdvecScheme` = 1 (default) uses a first-order centered stencil
+- `hAdvecScheme` = 2 uses a first-order upwind stencil

--- a/test/output_preservation_test.py
+++ b/test/output_preservation_test.py
@@ -60,6 +60,13 @@ def assert_outputs_close(nx, ny, layers, rtol):
             plt.savefig('blessed_output.png')
             plt.close()
 
+            plt.figure()
+            plt.pcolormesh(ans[:,:,0] - good_ans[:,:,0], cmap='RdBu_r')
+            plt.colorbar()
+            plt.title('current - blessed')
+            plt.savefig('difference.png')
+            plt.close()
+
         assert relerr < rtol
 
 def assert_volume_conservation(nx,ny,layers,rtol):

--- a/test/output_preservation_test.py
+++ b/test/output_preservation_test.py
@@ -289,6 +289,54 @@ def test_relative_wind():
         assert_volume_conservation(nx, ny, layers, 1e-5)
         assert_diagnostics_similar(['h', 'u', 'v'], 1e-10)
 
+def test_relative_wind_upwind_advection():
+    nx = 320
+    ny = 320
+    layers = 1
+    xlen = 1280e3
+    ylen = 1280e3
+    dx = xlen / nx
+    dy = ylen / ny
+
+    grid = aro.Grid(nx, ny, layers, dx, dy)
+
+    def wetmask(X, Y):
+        # water everywhere, doubly periodic
+        wetmask = np.ones(X.shape, dtype=np.float64)
+        return wetmask
+
+
+    def wind_x(X, Y):
+        rMx=300e3     # radius of circle where Max wind stress
+        r = np.sqrt((Y-640e3)**2 + (X-640e3)**2)
+        theta = np.arctan2(Y-640e3, X-640e3)
+        tau = np.sin(np.pi*r/rMx/2.)
+        tau_x = tau*np.sin(theta)
+        tau_x[r>2.*rMx] = 0
+
+        return tau_x
+
+    def wind_y(X, Y):
+        rMx=300e3     # radius of circle where Max wind stress
+        r = np.sqrt((Y-640e3)**2 + (X-640e3)**2)
+        theta = np.arctan2(Y-640e3, X-640e3)
+        tau = np.sin(np.pi*r/rMx/2.)
+        tau_y = -tau*np.cos(theta)
+        tau_y[r>2.*rMx] = 0
+        return tau_y
+
+    with working_directory(p.join(self_path, 
+        "relative_wind")):
+        drv.simulate(
+                initHfile=[400],
+                zonalWindFile=[wind_x], meridionalWindFile=[wind_y],
+                wind_mag_time_series_file=[0.08],
+                exe=test_executable, wetMaskFile=[wetmask],
+                nx=nx, ny=ny, dx=dx, dy=dy, hAdvecScheme=2)
+        assert_outputs_close(nx, ny, layers, 3e-11)
+        assert_volume_conservation(nx, ny, layers, 1e-5)
+        assert_diagnostics_similar(['h', 'u', 'v'], 1e-10)
+
 def test_periodic_BC_Hypre():
     nx = 50
     ny = 20


### PR DESCRIPTION
This implements an upwind advection scheme in the continuity equation and refactors the `evaluate_dhdt` subroutine. The refactor splits out the two diffusive contributions and the advective contribution into their own subroutines.

There are now two advection schemes available, and the parameter `hAdvScheme` is used to select between them (see additions to documentation). The upwind scheme changes the output, especially in regions with sharp gradients. However, the changes in the `relative_wind` test are small enough to allow both advection schemes to evaluate against the same blessed output, provided the tolerance is relaxed slightly for the upwind scheme.

This PR lays the groundwork for implementing a more sophisticated advection scheme, which will allow outcroppping (see #26). It also adds a slight enhancement to the test suite - when a test fails the difference between the blessed and current outputs is plotted in addition to both outputs. This change is a small step in the direction of #136.