### PR TITLE
Python 3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 language: python
 python:
   - "2.7"
+  - "3.6"
 
 dist: trusty
 sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_install:
   - sudo apt-get install openmpi-bin
   - sudo apt-get install imagemagick
   - pip install scipy
+  - pip install future
   - pip install sphinx
   - pip install sphinx_rtd_theme
   - pip install recommonmark

--- a/aronnax/core.py
+++ b/aronnax/core.py
@@ -11,6 +11,9 @@ from contextlib import contextmanager
 import os.path as p
 import re
 
+from builtins import str
+from builtins import int
+
 import numpy as np
 from scipy.io import FortranFile
 
@@ -136,7 +139,7 @@ def tracer_point_variable(grid, field_layers, *funcs):
     assert field_layers == len(funcs)
 
     for i, f in enumerate(funcs):
-        if isinstance(f, (int, long, float)):
+        if isinstance(f, (int, float)):
             T_variable[i,:,:] = f
         else:
             T_variable[i,:,:] = f(X, Y)
@@ -150,7 +153,7 @@ def u_point_variable(grid, field_layers, *funcs):
     assert field_layers == len(funcs)
 
     for i, f in enumerate(funcs):
-        if isinstance(f, (int, long, float)):
+        if isinstance(f, (int, float)):
             u_variable[i,:,:] = f
         else:
             u_variable[i,:,:] = f(X, Y)
@@ -164,7 +167,7 @@ def v_point_variable(grid, field_layers, *funcs):
     assert field_layers == len(funcs)
 
     for i, f in enumerate(funcs):
-        if isinstance(f, (int, long, float)):
+        if isinstance(f, (int, float)):
             v_variable[i,:,:] = f
         else:
             v_variable[i,:,:] = f(X, Y)
@@ -179,7 +182,7 @@ def time_series_variable(nTimeSteps, dt, func):
     assert len(func) == 1
 
     for i, f in enumerate(func):
-        if isinstance(f, (int, long, float)):
+        if isinstance(f, (int, float)):
             ts_variable[:] = np.ones(nTimeSteps) * f
         else:
             ts_variable[:] = f(nTimeSteps, dt)
@@ -282,7 +285,7 @@ def interpret_requested_data(requested_data, shape, config):
                 config.getfloat("grid", "dx"), config.getfloat("grid", "dy"))
     field_layers = find_field_layers(shape, grid)
 
-    if isinstance(requested_data, basestring):
+    if isinstance(requested_data, str):
         candidate = interpret_data_specifier(requested_data)
         if candidate is not None:
             (func, args) = candidate

--- a/aronnax/core.py
+++ b/aronnax/core.py
@@ -11,7 +11,7 @@ from contextlib import contextmanager
 import os.path as p
 import re
 
-from builtins import str
+from six import string_types
 from builtins import int
 
 import numpy as np
@@ -285,7 +285,7 @@ def interpret_requested_data(requested_data, shape, config):
                 config.getfloat("grid", "dx"), config.getfloat("grid", "dy"))
     field_layers = find_field_layers(shape, grid)
 
-    if isinstance(requested_data, str):
+    if isinstance(requested_data, string_types):
         candidate = interpret_data_specifier(requested_data)
         if candidate is not None:
             (func, args) = candidate

--- a/aronnax/driver.py
+++ b/aronnax/driver.py
@@ -1,8 +1,14 @@
-import ConfigParser as par
+try:
+    import configparser as par
+except ImportError:
+    import ConfigParser as par
+
 import os
 import os.path as p
 import subprocess as sub
 import time
+
+from future.utils import iteritems
 
 from aronnax.core import fortran_file
 from aronnax.core import interpret_requested_data
@@ -151,7 +157,7 @@ def merge_config(config, options):
     """Merge the options given in the `options` dict into the RawConfigParser instance `config`.
 
     Mutates the given config instance."""
-    for k, v in options.iteritems():
+    for k, v in iteritems(options):
         if k in section_map:
             section = section_map[k]
             if not config.has_section(section):
@@ -192,7 +198,7 @@ def is_file_name_option(name):
     return name.endswith("File") or name.endswith("file")
 
 def generate_input_data_files(config):
-    for name, section in section_map.iteritems():
+    for name, section in iteritems(section_map):
         if not is_file_name_option(name):
             continue
         if not config.has_option(section, name):
@@ -238,7 +244,7 @@ def generate_parameters_file(config):
             f.write(' &')
             f.write(section.upper())
             f.write('\n')
-            for (name, section1) in section_map.iteritems():
+            for (name, section1) in iteritems(section_map):
                 if section1 != section: continue
                 val = fortran_option_string(section, name, config)
                 if val is not None:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -10,7 +10,7 @@ While we aspire for the installation process for Aronnax to be as simple as :cod
 Dependencies
 ============
 
-Aronnax depends on several external libraries. 
+Aronnax is tested with Python 2.7 and 3.6, and depends on several external libraries. 
 
 The Python components of Aronnax depend on 
 

--- a/test/output_preservation_test.py
+++ b/test/output_preservation_test.py
@@ -11,6 +11,8 @@ import matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 
+from builtins import range
+
 import aronnax as aro
 import aronnax.driver as drv
 from aronnax.utils import working_directory
@@ -43,7 +45,7 @@ def assert_outputs_close(nx, ny, layers, rtol):
         good_ans = aro.interpret_raw_file(good_outfiles[i], nx, ny, layers)
         relerr = np.amax(array_relative_error(ans, good_ans))
         if (relerr >= rtol or np.isnan(relerr)):
-            print "test failed at " + outfile
+            print('test failed at {0}'.format(outfile))
             # print ans
             # print good_ans
             test_passes = False
@@ -80,7 +82,7 @@ def assert_volume_conservation(nx,ny,layers,rtol):
     volume_0 = np.zeros((layers))
     volume_final = np.zeros((layers))
 
-    for k in xrange(layers):
+    for k in range(layers):
         volume_0[k] = np.sum(h_0[:,:,k])
         volume_final[k] = np.sum(h_final[:,:,k])
 


### PR DESCRIPTION
Given the impending end of life for Python 2, Aronnax should support Python 3. This was highlighted during the JOSS review process: https://github.com/openjournals/joss-reviews/issues/592#issuecomment-382356615

This PR makes Aronnax compatible with Python 3, and updates the test suite to run under both Python 2.7 and 3.6, thereby closing #186.