### PR TITLE
Python3 compatibility for examples and benchmarks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ LIBS      = -L$(HYPRE_DIR)/lib -lHYPRE -lm
 
 src_dir = src/
 
-TEST_OPTS = -g -fprofile-arcs -ftest-coverage -O1 -fcheck=all -ffpe-trap=invalid,zero,overflow,underflow -Wuninitialized -Werror
+TEST_OPTS = -g -fprofile-arcs -ftest-coverage -O1 -fcheck=all -ffpe-trap=invalid,zero,overflow -Wuninitialized -Werror
 
 CORE_OPTS = -g -Ofast -fno-stack-arrays
 
@@ -23,7 +23,7 @@ HYPRE_PROF_objects = $(patsubst %, $(src_dir)%_HYPRE_PROF.o, $(FILES))
 
 # Profiling execuable
 aronnax_prof: $(PROF_objects) Makefile
-	mpif90 $(PROF_OPTS) $< -o $@ -cpp
+	mpif90 $(PROF_objects) $(PROF_OPTS) -o $@ -cpp
 
 %_PROF.o: %.f90
 	mpif90 $(PROF_OPTS) -J $(src_dir) -c $< -o $@ -cpp

--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -1,4 +1,4 @@
-import cPickle as pkl
+import pickle as pkl
 import os.path as p
 import sys
 
@@ -33,12 +33,12 @@ def benchmark_gaussian_bump_red_grav_save(grid_points):
             run_time_Ofast[counter] = aro.simulate(
                 exe=aro_exec, initHfile=[bump], nx=nx, ny=nx)
 
-        with open("times.pkl", "w") as f:
+        with open("times.pkl", "wb") as f:
             pkl.dump((grid_points, run_time_O1, run_time_Ofast), f)
 
 def benchmark_gaussian_bump_red_grav_plot():
     with working_directory(p.join(self_path, "beta_plane_bump_red_grav")):
-        with open("times.pkl", "r") as f:
+        with open("times.pkl", "rb") as f:
             (grid_points, run_time_O1, run_time_Ofast) = pkl.load(f)
 
         plt.figure()
@@ -91,7 +91,7 @@ def benchmark_gaussian_bump_save(grid_points):
             run_time_hypre[counter] = aro.simulate(
                 exe=aro_exec, initHfile=[bump, lambda X, Y: 2000. - bump(X, Y)], nx=nx, ny=nx)
 
-        with open("times.pkl", "w") as f:
+        with open("times.pkl", "wb") as f:
                 pkl.dump((grid_points, run_time_O1, run_time_Ofast,
                           run_time_hypre_test, run_time_hypre
                           ), f)
@@ -100,7 +100,7 @@ def benchmark_gaussian_bump_save(grid_points):
 
 def benchmark_gaussian_bump_plot():
     with working_directory(p.join(self_path, "beta_plane_bump")):
-        with open("times.pkl", "r") as f:
+        with open("times.pkl", "rb") as f:
             (grid_points, run_time_O1, run_time_Ofast,
                       run_time_hypre_test, run_time_hypre
                       ) = pkl.load(f)

--- a/benchmarks/profile.py
+++ b/benchmarks/profile.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import os.path as p
 import sys
 
@@ -36,17 +38,17 @@ def main():
         else:
             nx = int(arg)
     if red_grav:
-        print "Profiling a reduced gravity configuration" \
-            + " of size %dx%dx1 by 502 time steps." % (nx, nx)
+        print("Profiling a reduced gravity configuration" \
+                    + " of size %dx%dx1 by 502 time steps." % (nx, nx))
         do_red_grav(nx, aro_build, perf)
         outpath = p.join(self_path, "beta_plane_bump_red_grav", "gmon.out")
     else:
-        print "Profiling an n-layer configuration" \
-            + " of size %dx%dx2 by 502 time steps." % (nx, nx)
+        print("Profiling an n-layer configuration" \
+                    + " of size %dx%dx2 by 502 time steps." % (nx, nx))
         do_n_layer(nx, aro_build, perf)
         outpath = p.join(self_path, "beta_plane_bump", "gmon.out")
     if not perf:
-        print "Inspect %s,\nfor example with gprof aronnax_prof %s" % (outpath, outpath)
+        print("Inspect %s,\nfor example with gprof aronnax_prof %s" % (outpath, outpath))
 
 if __name__ == '__main__':
     main()

--- a/examples/run_examples.py
+++ b/examples/run_examples.py
@@ -1,7 +1,10 @@
+from __future__ import print_function
+
 import os
 import os.path as p
 import subprocess as sub
 import time
+from builtins import range
 
 import glob
 
@@ -50,7 +53,7 @@ def bump(X, Y):
 
 
 def beta_plane_bump_red_grav():
-    print "Running reduced gravity beta-plane bump example"
+    print("Running reduced gravity beta-plane bump example")
     xlen = 1e6
     ylen = 1e6
     nx = 100
@@ -68,7 +71,7 @@ def beta_plane_bump_red_grav():
             plt_output(grid, 'red-grav-bump')
 
 def beta_plane_bump_n_layer():
-    print "Running n-layer beta-plane bump example"
+    print("Running n-layer beta-plane bump example")
     xlen = 1e6
     ylen = 1e6
     nx = 100
@@ -85,7 +88,7 @@ def beta_plane_bump_n_layer():
             plt_output(grid, 'n-layer-bump')
 
 def beta_plane_gyre_red_grav():
-    print "Running reduced gravity beta-plane gyre example"
+    print("Running reduced gravity beta-plane gyre example")
     xlen = 1e6
     ylen = 2e6
     nx = 100 
@@ -117,7 +120,7 @@ def beta_plane_gyre_red_grav():
             plt_output(grid, 'red-grav-twin-gyre', colour_lim=20)
 
 def beta_plane_gyre_n_layer():
-    print "Running n-layer beta-plane gyre example"
+    print("Running n-layer beta-plane gyre example")
     xlen = 1e6
     ylen = 2e6
     nx = 100
@@ -157,7 +160,7 @@ def plt_output(grid, sim_name, colour_lim=2):
 
     # plot each state of the run
 
-    for i in xrange(len(v_files)):
+    for i in range(len(v_files)):
         h = aro.interpret_raw_file(h_files[i], grid.nx, grid.ny, grid.layers)
         v = aro.interpret_raw_file(v_files[i], grid.nx, grid.ny, grid.layers)
 
@@ -189,7 +192,7 @@ def plt_output(grid, sim_name, colour_lim=2):
     try:
         sub.check_call(["convert", "-delay", "30", "-loop", "0", "state_*.png", "{0}.gif".format(sim_name)])
     except:
-        print "failed to make animation"
+        print("failed to make animation")
 
 
 if __name__ == '__main__':

--- a/reproductions/Davis_et_al_2014/control/aronnax.conf
+++ b/reproductions/Davis_et_al_2014/control/aronnax.conf
@@ -58,4 +58,5 @@ initHfile = :tracer_point_variable:400.0
 
 [external_forcing]
 DumpWind = no
+RelativeWind = no
 

--- a/reproductions/Davis_et_al_2014/control_final_five/aronnax.conf
+++ b/reproductions/Davis_et_al_2014/control_final_five/aronnax.conf
@@ -58,4 +58,4 @@ initHfile = :tracer_point_variable:400.0
 
 [external_forcing]
 DumpWind = no
-
+RelativeWind = no

--- a/reproductions/plot_Davis_et_al_2014.py
+++ b/reproductions/plot_Davis_et_al_2014.py
@@ -2,6 +2,7 @@ import os
 import os.path as p
 
 import glob
+from builtins import range
 
 import numpy as np
 import matplotlib
@@ -30,7 +31,7 @@ def plt_h_cross_section(simulation=None):
     h_final = aro.interpret_raw_file(h_files[-1],102,182,1,)
 
     plt.figure()
-    for i in xrange(100,160):
+    for i in range(100,160):
         plt.plot(h_final[:,i,0])
     plt.savefig('{0}figures/h_final.png'.format(simulation))
     plt.close()
@@ -41,7 +42,7 @@ def plt_state(simulation=None):
 
     h_max = np.zeros(len(h_files))
 
-    for i in xrange(len(v_files)):
+    for i in range(len(v_files)):
         h = aro.interpret_raw_file(h_files[i], 102, 182, 1)
         h_max[i] = np.max(h)
 
@@ -85,7 +86,7 @@ def plot_channel_transport(simulation=None):
 
     transport = np.zeros(len(h_files))
 
-    for i in xrange(len(v_files)):
+    for i in range(len(v_files)):
         h = aro.interpret_raw_file(h_files[i], 102, 182, 1)
         v = aro.interpret_raw_file(v_files[i], 102, 182, 1)
 


### PR DESCRIPTION
In #189 I managed to miss the reproduction, example, and benchmarking scripts. Several of these hadn't been updated in quite some time, and the Davis et al. reproduction didn't run because the config file was missing the `RelativeWind` flag.

While making the benchmarking script compatible with Python 3 I found that the addition of the compiler flag to catch underflow errors caused the model to stop. Squaring very small velocities in the computation of the Bernoulli potential lead to underflow warnings, and the flag was turning these warnings into errors. As mentioned in #191 I've just removed that flag. 