### PR TITLE
Output handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,11 @@ before_install:
   - sudo apt-get install openmpi-bin
   - sudo apt-get install imagemagick
   - pip install scipy
+  - pip install numpy
+  - pip install pandas
+  - pip install xarray
+  - pip install toolz
+  - pip install dask
   - pip install future
   - pip install sphinx
   - pip install sphinx_rtd_theme

--- a/aronnax/core.py
+++ b/aronnax/core.py
@@ -152,9 +152,14 @@ def interpret_raw_file_delayed(name, nx, ny, layers):
 
 def open_mfdataarray(files, grid):
     """Open a number of output files into an xarray dataarray. All files
-        must contain the same variable.
+    must contain the same variable.
 
-    Uses dask.delyaed to lazily load data as required.
+    Uses dask.delayed to lazily load data as required.
+
+    :param list files: a list of file names to load
+    :param grid: a grid object created by aronnax.Grid
+
+    :return: xarray.DataArray of the desired variable
     """
 
     files = sorted(files)

--- a/aronnax/core.py
+++ b/aronnax/core.py
@@ -177,7 +177,6 @@ def open_mfdataarray(files, grid):
     if len(output_variables) > 1:
         raise ValueError\
         ('open_mfdataarray only supports loading multiple timestamps of a single variable.')
-        return
 
     datasets = [interpret_raw_file_delayed(file_name, grid.nx,
                                             grid.ny, grid.layers)

--- a/aronnax/core.py
+++ b/aronnax/core.py
@@ -124,9 +124,10 @@ def interpret_raw_file(name, nx, ny, layers):
         dx = 1
     if file_part.startswith("debug.dvdt"):
         dy = 1
+
     with fortran_file(name, 'r') as f:
         return f.read_reals(dtype=np.float64) \
-                    .reshape(layers, ny+dy, nx+dx).transpose()
+                    .reshape(layers, ny+dy, nx+dx)
 
 
 ### General input construction helpers

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -5,12 +5,19 @@ Development
 Since latest release
 --------------------
 
+- Python functions now have axis order specified by Comodo conventions `GH204 <https://github.com/edoddridge/aronnax/pull/204>`_ (13 July 2018)
+- Python wrapper can lazily load multiple timestamps into a 4D array (t,z,y,x) `GH204 <https://github.com/edoddridge/aronnax/pull/204>`_ (13 July 2018)
+
+
+Version 0.2.0 (15 June 2018)
+--------------------------------
+
 - Allow outcropping `GH196 <https://github.com/edoddridge/aronnax/pull/196>`_ (30 April 2018)
 - Add Python 3 compatibility `GH189 <https://github.com/edoddridge/aronnax/pull/189>`_ (23 April 2018)
 - Add Adams-Bashforth family of timestepping algorithms up to fifth-order `GH184 <https://github.com/edoddridge/aronnax/pull/184>`_ (15 March 2018)
 - Make test suite plot all differences when a test fails, as suggested in `GH136 <https://github.com/edoddridge/aronnax/issues/136>`_ and implemented in `GH181 <https://github.com/edoddridge/aronnax/pull/181>`_ (12 March 2018)
 - Refactor Fortran code into modules in src/ directory `GH181 <https://github.com/edoddridge/aronnax/pull/181>`_ (12 March 2018)
-- Add option for first-order upwind advction scheme `GH179 <https://github.com/edoddridge/aronnax/pull/179>`_ (8 March 2018)
+- Add option for first-order upwind advection scheme `GH179 <https://github.com/edoddridge/aronnax/pull/179>`_ (8 March 2018)
 - Add vertical diffusion of mass between layers `GH177 <https://github.com/edoddridge/aronnax/pull/177>`_ (2 March 2018)
 
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -18,7 +18,11 @@ The Python components of Aronnax depend on
 | :bash:`scipy`
 |
 
-We recommend installing these with your favourite package manager before installing Aronnax.
+We recommend installing these with your favourite package manager before installing Aronnax. While the previous dependencies will allow you to run the model, some of the functions for dealing with the output files also depend on
+
+| :bash:`xarray`
+| :bash:`dask`
+|
 
 Additionally, the Fortran core requires
 

--- a/docs/output.rst
+++ b/docs/output.rst
@@ -7,6 +7,12 @@ Aronnax produces output in two formats. The full fields are saved in Fortran unf
 Reading the data
 ===================
 
-Aronnax includes a helper function for dealing with the unformatted output.
+Aronnax includes a number of helper functions for dealing with the unformatted Fortran output.
+
+The simplest of these is `interpret_raw_file` which loads a single output of a single variable into a numpy array.
 
 .. autofunction:: aronnax.interpret_raw_file
+
+Aronnax also ships with a function for lazily loading multiple timestamps of a single variable. This function uses `xarray <http://xarray.pydata.org/en/stable/>`_ and `dask <http://dask.pydata.org/en/latest/docs.html>`_ to create labeled n-dimensional arrays.
+
+.. autofunction:: aronnax.open_mfdataarray

--- a/examples/run_examples.py
+++ b/examples/run_examples.py
@@ -167,12 +167,12 @@ def plt_output(grid, sim_name, colour_lim=2):
         X,Y = np.meshgrid(grid.x/1e3, grid.y/1e3)
 
         plt.figure()
-        CS = plt.contour(X,Y,np.transpose(h[:,:,0]),colors='k')
+        CS = plt.contour(X,Y,h[0,:,:],colors='k')
         plt.clabel(CS, inline=1, inline_spacing=17,
          fontsize=10, fmt=r'%3.0f')
         X,Y = np.meshgrid(grid.x/1e3, grid.yp1/1e3)
 
-        im = plt.pcolormesh(X,Y,np.transpose(v[:,:,0])*100., cmap='RdBu_r'
+        im = plt.pcolormesh(X,Y,v[0,:,:]*100., cmap='RdBu_r'
             ,vmin = -colour_lim, vmax = colour_lim)
         im.set_edgecolor('face')
         CB = plt.colorbar()

--- a/reproductions/Yang_et_al_2016/plot_spin_up.py
+++ b/reproductions/Yang_et_al_2016/plot_spin_up.py
@@ -68,14 +68,14 @@ def plt_h_cross_section(simulation=None):
 
     plt.figure()
     for i in range(100,160):
-        plt.plot(-h_final[:,i,0])
+        plt.plot(-h_final[0,i,:])
     plt.title('Timestep {}: Day {:05d}'.format(h_files[-1][-10:], len(h_files)))
     plt.savefig('{0}figures/h_final.png'.format(simulation))
     plt.close()
 
-    plt.pcolormesh(X_h, Y_h, np.transpose(h_final[:,:,0]))
+    plt.pcolormesh(X_h, Y_h, h_final[0,:,:])
     plt.colorbar()
-    plt.contour(X_h, Y_h, np.transpose(h_final[:,:,0]), np.arange(0,800,50), colors='k')
+    plt.contour(X_h, Y_h, h_final[0,:,:], np.arange(0,800,50), colors='k')
     plt.title('Timestep {}: Day {:05d}'.format(h_files[-1][-10:], len(h_files)))
     plt.savefig('{0}figures/h_final_pcolor.png'.format(simulation))
     plt.close()
@@ -89,7 +89,7 @@ def plt_state(simulation=None):
 
     for i in range(len(v_files)):
         h = aro.interpret_raw_file(h_files[i], nx, ny, layers)
-        h_max[i] = h[100,100,0] #np.max(h[:,:,0])
+        h_max[i] = h[0,100,100] #np.max(h[0,:,:])
     
     years = np.arange(len(h_max))/360
     plt.figure()
@@ -107,9 +107,9 @@ def plt_state(simulation=None):
         f, (ax1, ax2) = plt.subplots(1, 2, figsize=(10,5))
         ax1.pcolormesh(X_h, Y_h, np.ma.masked_where(mask_h==1, mask_h), cmap='YlOrBr_r',
             vmin=0, vmax=1)
-        CS = ax1.contour(X_h, Y_h, np.transpose(h[:,:,0]), np.arange(0,800,50), colors='k')
+        CS = ax1.contour(X_h, Y_h, h[0,:,:], np.arange(0,800,50), colors='k')
 
-        im = ax1.pcolormesh(X_v, Y_v, np.ma.masked_where(mask_v==0, np.transpose(v[:,:,0])*100.),
+        im = ax1.pcolormesh(X_v, Y_v, np.ma.masked_where(mask_v==0, v[0,:,:]*100.),
             cmap='RdBu_r', vmin = -75, vmax = 75)
         CB = plt.colorbar(im, ax=ax1, orientation='horizontal')
         CB.set_label('y component of velocity (cm / s)')
@@ -136,10 +136,10 @@ def plt_state(simulation=None):
         plt.figure()
         plt.pcolormesh(X_h, Y_h, np.ma.masked_where(mask_h==1, mask_h), cmap='YlOrBr_r',
             vmin=0, vmax=1)
-        CS = plt.contour(X_h, Y_h, np.transpose(h[:,:,1]), np.arange(0,5000,500),
+        CS = plt.contour(X_h, Y_h, h[1,:,:], np.arange(0,5000,500),
             colors='k')
 
-        plt.pcolormesh(X_v, Y_v, np.ma.masked_where(mask_v==0, np.transpose(v[:,:,1])*100.),
+        plt.pcolormesh(X_v, Y_v, np.ma.masked_where(mask_v==0, v[1,:,:]*100.),
             cmap='RdBu_r', vmin = -15, vmax = 15)
         CB = plt.colorbar()
         CB.set_label('y component of velocity (cm / s)')

--- a/reproductions/Yang_et_al_2016/plotly_3d_surface_aronnax.py
+++ b/reproductions/Yang_et_al_2016/plotly_3d_surface_aronnax.py
@@ -67,15 +67,15 @@ v_files = sorted(glob.glob(p.join(file_path, 'snap.v.*')))
 
 
 h_final = aro.interpret_raw_file(h_files[-1], nx, ny, layers)
-h_masked = np.ma.masked_where(mask_h==0, h_final[:,:,0])
+h_masked = np.ma.masked_where(mask_h==0, h_final[0,:,:])
 u_final = aro.interpret_raw_file(u_files[-1], nx, ny, layers)
 v_final = aro.interpret_raw_file(v_files[-1], nx, ny, layers)
 
-speed = np.sqrt((u_final[:-1,:,0]+u_final[1:,:,0])**2 + (v_final[:,1:,0] + v_final[:,:-1,0])**2)
+speed = np.sqrt((u_final[0,:,:-1]+u_final[0,:,1:])**2 + (v_final[:,1:,0] + v_final[:,:-1,0])**2)
 speed[mask_h==0] = np.nan
 
 eta_final = aro.interpret_raw_file(eta_files[-1], nx, ny, 1)
-eta_masked = np.ma.masked_where(mask_h==0, eta_final[:,:,0])*1e2
+eta_masked = np.ma.masked_where(mask_h==0, eta_final[0,:,:])*1e2
 eta_masked = eta_masked - np.min(eta_masked)
 
 data = [go.Surface(x=grid.x/1e3, y=grid.y/1e3, z=-h_masked,

--- a/reproductions/plot_Davis_et_al_2014.py
+++ b/reproductions/plot_Davis_et_al_2014.py
@@ -53,11 +53,11 @@ def plt_state(simulation=None):
     X,Y = np.meshgrid(grid.x/1e3, grid.y/1e3)
 
     plt.figure()
-    CS = plt.contour(X,Y,np.transpose(h[:,:,0]),colors='k')
+    CS = plt.contour(X,Y,h[0,:,:],colors='k')
     plt.clabel(CS, inline=1, fontsize=10)
     X,Y = np.meshgrid(grid.x/1e3, grid.yp1/1e3)
 
-    plt.pcolormesh(X,Y,np.transpose(v[:,:,0])*100., cmap='RdBu_r'
+    plt.pcolormesh(X,Y,v[0,:,:]*100., cmap='RdBu_r'
         ,vmin = -2, vmax = 2)
     CB = plt.colorbar()
     CB.set_label('y component of velocity (cm / s)')
@@ -91,7 +91,7 @@ def plot_channel_transport(simulation=None):
         v = aro.interpret_raw_file(v_files[i], 102, 182, 1)
 
 
-        transport[i] = np.sum(h[:,70,0]*(v[:,53,0]+v[:,54,0])/2.)*grid.dx/1e6
+        transport[i] = np.sum(h[0,70,:]*(v[0,53,:]+v[0,54,:])/2.)*grid.dx/1e6
 
     plt.figure()
 

--- a/test/output_preservation_test.py
+++ b/test/output_preservation_test.py
@@ -46,26 +46,27 @@ def assert_outputs_close(nx, ny, layers, rtol):
         relerr = np.amax(array_relative_error(ans, good_ans))
         if (relerr >= rtol or np.isnan(relerr)):
             print('test failed at {0}'.format(outfile))
+            print('rtol = {0}: relerr = {1}'.format(rtol, relerr))
             # print ans
             # print good_ans
             test_passes = False
 
             plt.figure()
-            plt.pcolormesh(ans[:,:,0])
+            plt.pcolormesh(ans[0,:,:])
             plt.colorbar()
             plt.title(outfile)
             plt.savefig('current_output_{0}.png'.format(outfile[12:]))
             plt.close()
 
             plt.figure()
-            plt.pcolormesh(good_ans[:,:,0])
+            plt.pcolormesh(good_ans[0,:,:])
             plt.colorbar()
             plt.title(outfile)
             plt.savefig('blessed_output_{0}.png'.format(outfile[12:]))
             plt.close()
 
             plt.figure()
-            plt.pcolormesh(ans[:,:,0] - good_ans[:,:,0], cmap='RdBu_r')
+            plt.pcolormesh(ans[0,:,:] - good_ans[0,:,:], cmap='RdBu_r')
             plt.colorbar()
             plt.title('current - blessed at {0}'.format(outfile[12:]))
             plt.savefig('difference_{0}.png'.format(outfile[12:]))
@@ -83,8 +84,8 @@ def assert_volume_conservation(nx,ny,layers,rtol):
     volume_final = np.zeros((layers))
 
     for k in range(layers):
-        volume_0[k] = np.sum(h_0[:,:,k])
-        volume_final[k] = np.sum(h_final[:,:,k])
+        volume_0[k] = np.sum(h_0[k,:,:])
+        volume_final[k] = np.sum(h_final[k,:,:])
 
         assert np.abs((volume_0[k] - volume_final[k])/volume_0[k]) < rtol
 

--- a/test/physics_tests.py
+++ b/test/physics_tests.py
@@ -109,10 +109,10 @@ def f_plane_init_u_test(physics, aro_exec, dt):
             # plt.savefig('h.{0}.png'.format(ufile[-10:]),dpi=150)
             # plt.close()
 
-            energy[counter] = nx * ny * (dx * dy * rho0 * (np.sum(np.absolute(h * (u[1:,...]**2 + u[:-1,...]**2)/4.)/2.) + np.sum(np.absolute(h * (v[:,1:,:]**2 + v[:,:-1,:]**2)/4.)/2.)) +  
+            energy[counter] = nx * ny * (dx * dy * rho0 * (np.sum(np.absolute(h * (u[:,:,1:]**2 + u[:,:,:-1]**2)/4.)/2.) + np.sum(np.absolute(h * (v[:,1:,:]**2 + v[:,:-1,:]**2)/4.)/2.)) +  
               dx * dy * rho0 * 0.01 * np.sum(np.absolute(h - 400.)))
 
-            momentum[counter] = nx * ny * dx * dy * rho0 * (np.sum(np.absolute(h * (u[1:,...] + u[:-1,...])/2.)) + np.sum(np.absolute(h * (v[:,1:,:] + v[:,:-1,:])/2.)))
+            momentum[counter] = nx * ny * dx * dy * rho0 * (np.sum(np.absolute(h * (u[:,:,1:] + u[:,:,:-1])/2.)) + np.sum(np.absolute(h * (v[:,1:,:] + v[:,:-1,:])/2.)))
 
             volume[counter] = np.sum(h)
 
@@ -130,9 +130,9 @@ def f_plane_init_u_test(physics, aro_exec, dt):
         X, Y = np.meshgrid(grid.x, grid.yp1)
         init_v = aro.interpret_raw_file(vfiles[1], nx, ny, layers) #init_V(X, Y, True)
 
-        energy_expected[:] = nx * ny * (dx * dy * rho0 * (np.sum(np.absolute(400. * (init_u[1:,...]**2 + init_u[:-1,...]**2)/4.)/2.) + np.sum(np.absolute(400. * (init_v[:,1:,:]**2 + init_v[:,:-1,:]**2)/4.)/2.)) )
+        energy_expected[:] = nx * ny * (dx * dy * rho0 * (np.sum(np.absolute(400. * (init_u[:,:,1:]**2 + init_u[:,:,:-1]**2)/4.)/2.) + np.sum(np.absolute(400. * (init_v[:,1:,:]**2 + init_v[:,:-1,:]**2)/4.)/2.)) )
 
-        momentum_expected[:] = nx * ny * dx * dy * rho0 * (np.sum(np.absolute(h * (init_u[1:,...] + init_u[:-1,...])/2.)) + np.sum(np.absolute(h * (init_v[:,1:,:] + init_v[:,:-1,:])/2.)))
+        momentum_expected[:] = nx * ny * dx * dy * rho0 * (np.sum(np.absolute(h * (init_u[:,:,1:] + init_u[:,:,:-1])/2.)) + np.sum(np.absolute(h * (init_v[:,1:,:] + init_v[:,:-1,:])/2.)))
 
         # print momentum[0]/momentum_expected[0]
 
@@ -271,7 +271,7 @@ def f_plane_wind_test(physics, aro_exec, nx, ny, dx, dy, dt, nTimeSteps):
             # plt.savefig('h.{0}.png'.format(ufile[-10:]),dpi=150)
             # plt.close()
 
-            momentum[counter] = dx * dy * rho0 * (np.sum(np.absolute(h * (u[1:,...] + u[:-1,...])/2.)) + np.sum(np.absolute(h * (v[:,1:,:] + v[:,:-1,:])/2.)))
+            momentum[counter] = dx * dy * rho0 * (np.sum(np.absolute(h * (u[:,:,1:] + u[:,:,:-1])/2.)) + np.sum(np.absolute(h * (v[:,1:,:] + v[:,:-1,:])/2.)))
 
             momentum_expected[counter] =  2.* dx * dy * 1e-5 * (model_iteration[counter] + 2) * dt
 

--- a/test/physics_tests.py
+++ b/test/physics_tests.py
@@ -21,6 +21,7 @@ import output_preservation_test as opt
 
 import subprocess as sub
 
+from builtins import int    # subclass of long on Py2
 
 
 def f_plane_init_u_test(physics, aro_exec, dt):
@@ -336,7 +337,7 @@ def f_plane_wind_test(physics, aro_exec, nx, ny, dx, dy, dt, nTimeSteps):
 
 def truncation_error(physics, aro_exec, nx, ny, grid_resolution, integration_time):
 
-    if isinstance(grid_resolution, (int, long, float)):
+    if isinstance(grid_resolution, (int, float)):
         dx = grid_resolution
         dt = 30. #np.min([dx/10., 1000.])
 

--- a/test/read_output_test.py
+++ b/test/read_output_test.py
@@ -1,0 +1,50 @@
+'''Unit tests for Aronnax'''
+
+from contextlib import contextmanager
+import os.path as p
+import re
+
+import numpy as np
+from scipy.io import FortranFile
+
+import aronnax as aro
+from aronnax.utils import working_directory
+
+import pytest
+import glob
+
+self_path = p.dirname(p.abspath(__file__))
+
+def test_open_mfdataarray():
+    '''Open a number of files and assert that the length of the time
+        dimension is the same as the number of files.'''
+    
+    xlen = 1e6
+    ylen = 2e6
+    nx = 10; ny = 20
+    layers = 1
+    grid = aro.Grid(nx, ny, layers, xlen / nx, ylen / ny)
+
+    with working_directory(p.join(self_path, "beta_plane_gyre_red_grav")):
+        output_files = glob.glob('output/snap.h*')
+        ds = aro.open_mfdataarray(output_files, grid)
+
+        assert len(output_files) == ds.time.shape[0]
+
+    
+
+def test_open_mfdataarray_multiple_variables():
+    '''This test tries to open multiple different variables in the same call,
+        and should fail.'''
+    
+    xlen = 1e6
+    ylen = 2e6
+    nx = 10; ny = 20
+    layers = 1
+    grid = aro.Grid(nx, ny, layers, xlen / nx, ylen / ny)
+
+    with working_directory(p.join(self_path, "beta_plane_gyre_red_grav")):
+        with pytest.raises(Exception):
+            output_files = glob.glob('output/snap.*')
+            ds = aro.open_mfdataarray(output_files, grid)
+            


### PR DESCRIPTION
A grab bag of fixes and new features related to handling model output.

This PR implements a fix for #197 and ensures that the output is presented to users with axes in the order (z,y,x). It also implements a function to lazily load in multiple timestamps of a field. This new function provides some metadata for the array (axis labels and values). The metadata could be expanded, and perhaps even by making the function automatically look for `aronnax-merged.conf` and ingest lots of metadata from there.

Finally, some tests were added for the new functionality which required the addition of some more modules to the Travis install.