### PR TITLE
Open_mfdatarray bug fix

### DIFF
--- a/aronnax/core.py
+++ b/aronnax/core.py
@@ -83,8 +83,19 @@ def interpret_raw_file(name, nx, ny, layers):
     # rate of change as one traverses the elements sequentially,
     # whereas Python (and all other programming languages I am aware
     # of) indexes in increasing order.
+
+    dx, dy, layers = __find_grid_offsets(name, nx, ny, layers)
+
+    with fortran_file(name, 'r') as f:
+        return f.read_reals(dtype=np.float64) \
+                    .reshape(layers, ny+dy, nx+dx)
+
+
+def __find_grid_offsets(name, nx, ny, layers):
+    """Internal function for determining location of variable on the grid."""
+
     file_part = p.basename(name)
-    dx = 0; dy = 0;
+    dx = 0; dy = 0; layers = layers;
     if file_part.startswith("snap.BP."):
         pass
     elif file_part.startswith("snap.eta."):
@@ -132,12 +143,10 @@ def interpret_raw_file(name, nx, ny, layers):
         print('File not recognised - no output returned')
         return
 
-    with fortran_file(name, 'r') as f:
-        return f.read_reals(dtype=np.float64) \
-                    .reshape(layers, ny+dy, nx+dx)
+    return dx, dy, layers
 
 
-def interpret_raw_file_delayed(name, nx, ny, layers):
+def interpret_raw_file_delayed(name, nx, ny, layers, dx, dy):
     """
     Use Dask.delayed to lazily load a single output file. While this can be
     used as is, it is intended to be an internal function called by `open_mfdataset`.
@@ -146,7 +155,7 @@ def interpret_raw_file_delayed(name, nx, ny, layers):
     variable_name = '.'.join(variable_name.split('.')[:-1])
 
     d = dsa.from_delayed(delayed(interpret_raw_file)(name, nx, ny, layers),
-                            (layers, ny, nx), float, name=variable_name)
+                            (layers, ny+dy, nx+dx), float, name=variable_name)
     return d
 
 
@@ -178,17 +187,47 @@ def open_mfdataarray(files, grid):
         raise ValueError\
         ('open_mfdataarray only supports loading multiple timestamps of a single variable.')
 
+    dx, dy, layers = __find_grid_offsets(files[0], grid.nx, grid.ny, grid.layers)
+
     datasets = [interpret_raw_file_delayed(file_name, grid.nx,
-                                            grid.ny, grid.layers)
+                                            grid.ny, layers, dx, dy)
                 for file_name in files]
     
     ds = dsa.stack(datasets, axis=0)
 
-    ds = xr.DataArray(ds, coords=dict(time=timestamps,
-                                        layers=np.arange(grid.layers),
+    if dx ==1 and dy == 1:
+        # variable at vorticity location
+        ds = xr.DataArray(ds, coords=dict(time=timestamps,
+                                        layers=np.arange(layers),
+                                        yp1=grid.yp1, xp1=grid.xp1),
+                        dims=['time','layers','yp1','xp1'],
+                        name=output_variables[0])
+    elif dx == 1:
+        # variable at u location
+        ds = xr.DataArray(ds, coords=dict(time=timestamps,
+                                        layers=np.arange(layers),
+                                        y=grid.y, xp1=grid.xp1),
+                        dims=['time','layers','y','xp1'],
+                        name=output_variables[0])
+    elif dy == 1:
+        # variable at v location
+        ds = xr.DataArray(ds, coords=dict(time=timestamps,
+                                        layers=np.arange(layers),
+                                        yp1=grid.yp1, x=grid.x),
+                        dims=['time','layers','yp1','x'],
+                        name=output_variables[0])
+    elif dx == 0 and dy ==0:
+        # variable at h location
+        ds = xr.DataArray(ds, coords=dict(time=timestamps,
+                                        layers=np.arange(layers),
                                         y=grid.y, x=grid.x),
                         dims=['time','layers','y','x'],
                         name=output_variables[0])
+    else:
+        # not able to determine where we are
+        raise ValueError('Unable to determine grid location')
+        return
+
     return ds
 
 

--- a/aronnax/core.py
+++ b/aronnax/core.py
@@ -95,7 +95,7 @@ def __find_grid_offsets(name, nx, ny, layers):
     """Internal function for determining location of variable on the grid."""
 
     file_part = p.basename(name)
-    dx = 0; dy = 0; layers = layers;
+    dx = 0; dy = 0;
     if file_part.startswith("snap.BP."):
         pass
     elif file_part.startswith("snap.eta."):
@@ -226,7 +226,6 @@ def open_mfdataarray(files, grid):
     else:
         # not able to determine where we are
         raise ValueError('Unable to determine grid location')
-        return
 
     return ds
 

--- a/test/read_output_test.py
+++ b/test/read_output_test.py
@@ -15,10 +15,52 @@ import glob
 
 self_path = p.dirname(p.abspath(__file__))
 
-def test_open_mfdataarray():
+
+def test_open_mfdataarray_u_location():
     '''Open a number of files and assert that the length of the time
-        dimension is the same as the number of files.'''
-    
+        dimension is the same as the number of files, and that the
+        correct x and y variables have been used.'''
+
+    xlen = 1e6
+    ylen = 2e6
+    nx = 10; ny = 20
+    layers = 1
+    grid = aro.Grid(nx, ny, layers, xlen / nx, ylen / ny)
+
+    with working_directory(p.join(self_path, "beta_plane_gyre_red_grav")):
+
+        output_files = glob.glob('output/snap.u*')
+        ds = aro.open_mfdataarray(output_files, grid)
+
+        assert len(output_files) == ds.time.shape[0]
+        assert nx+1 == ds.xp1.shape[0]
+        assert ny == ds.y.shape[0]
+
+def test_open_mfdataarray_v_location():
+    '''Open a number of files and assert that the length of the time
+        dimension is the same as the number of files, and that the
+        correct x and y variables have been used.'''
+
+    xlen = 1e6
+    ylen = 2e6
+    nx = 10; ny = 20
+    layers = 1
+    grid = aro.Grid(nx, ny, layers, xlen / nx, ylen / ny)
+
+    with working_directory(p.join(self_path, "beta_plane_gyre_red_grav")):
+
+        output_files = glob.glob('output/snap.v*')
+        ds = aro.open_mfdataarray(output_files, grid)
+
+        assert len(output_files) == ds.time.shape[0]
+        assert nx == ds.x.shape[0]
+        assert ny+1 == ds.yp1.shape[0]
+
+def test_open_mfdataarray_h_location():
+    '''Open a number of files and assert that the length of the time
+        dimension is the same as the number of files, and that the
+        correct x and y variables have been used.'''
+
     xlen = 1e6
     ylen = 2e6
     nx = 10; ny = 20
@@ -30,7 +72,8 @@ def test_open_mfdataarray():
         ds = aro.open_mfdataarray(output_files, grid)
 
         assert len(output_files) == ds.time.shape[0]
-
+        assert nx == ds.x.shape[0]
+        assert ny == ds.y.shape[0]
     
 
 def test_open_mfdataarray_multiple_variables():


### PR DESCRIPTION
The function `open_mfdataarray` didn't respect the location of the variables on the grid. This PR introduces a test that can detect that behaviour, and a fix for the problem.

