### PR TITLE
Bugfix: bottom drag

### DIFF
--- a/src/momentum.f90
+++ b/src/momentum.f90
@@ -341,13 +341,15 @@ module momentum
               dudt_drag(i,j,k) = - 1.0d0*ar*(u(i,j,k) - 1.0d0*u(i,j,k+1))
             else if (k .eq. layers) then ! bottom layer
               dudt_drag(i,j,k) = - 1.0d0*ar*(u(i,j,k) - 1.0d0*u(i,j,k-1))
-              if (.not. RedGrav) then
-                ! add bottom drag here in isopycnal version
-                dudt_drag(i,j,k) = dudt_drag(i,j,k) - 1.0d0*botDrag*(u(i,j,k))
-              end if
             else ! mid layer/s
               dudt_drag(i,j,k) = - &
                   1.0d0*ar*(2.0d0*u(i,j,k) - 1.0d0*u(i,j,k-1) - 1.0d0*u(i,j,k+1))
+            end if
+          end if
+          if (k .eq. layers) then ! add bottom drag if not reduced gravity
+            if (.not. RedGrav) then
+                ! add bottom drag here in isopycnal version
+                dudt_drag(i,j,k) = dudt_drag(i,j,k) - 1.0d0*botDrag*(u(i,j,k))
             end if
           end if
         end do
@@ -696,13 +698,15 @@ module momentum
               dvdt_drag(i,j,k) =  - 1.0d0*ar*(v(i,j,k) - 1.0d0*v(i,j,k+1))
             else if (k .eq. layers) then ! bottom layer
               dvdt_drag(i,j,k) =  - 1.0d0*ar*(v(i,j,k) - 1.0d0*v(i,j,k-1))
-              if (.not. RedGrav) then
-                ! add bottom drag here in isopycnal version
-                dvdt_drag(i,j,k) = dvdt_drag(i,j,k) - 1.0d0*botDrag*(v(i,j,k))
-              end if
             else ! mid layer/s
               dvdt_drag(i,j,k) =  - &
                   1.0d0*ar*(2.0d0*v(i,j,k) - 1.0d0*v(i,j,k-1) - 1.0d0*v(i,j,k+1))
+            end if
+          end if
+          if (k .eq. layers) then ! add bottom drag if not reduced gravity
+            if (.not. RedGrav) then
+              ! add bottom drag here in isopycnal version
+              dvdt_drag(i,j,k) = dvdt_drag(i,j,k) - 1.0d0*botDrag*(v(i,j,k))
             end if
           end if
         end do

--- a/test/botDrag_test.py
+++ b/test/botDrag_test.py
@@ -1,0 +1,153 @@
+import os.path as p
+
+import glob
+
+import numpy as np
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+import aronnax as aro
+import aronnax.driver as drv
+from aronnax.utils import working_directory
+
+self_path = p.dirname(p.abspath(__file__))
+root_path = p.dirname(self_path)
+
+import sys
+sys.path.append(p.join(root_path, 'test'))
+import output_preservation_test as opt
+
+import subprocess as sub
+
+from builtins import int    # subclass of long on Py2
+
+
+def test_f_plane_Hypre_botDrag(botDrag=1e-5, layers=1):
+
+    test_executable = "aronnax_external_solver_test"
+
+    dt = 100
+
+    nx = 10
+    ny = 10
+    dx = 1e3
+    dy = 1e3
+
+    rho0 = 1035.
+
+    grid = aro.Grid(nx, ny, layers, dx, dy)
+
+
+    def init_U(X, Y, *arg):
+        init_u = np.zeros(Y.shape,dtype=np.float64)
+        init_u[:,:] = 3e-5
+
+        return init_u
+
+    def dbl_periodic_wetmask(X, Y):
+        return np.ones(X.shape,dtype=np.float64)
+
+    with working_directory(p.join(self_path, "bot_drag")):
+
+        if layers ==1:
+            drv.simulate(initHfile=[400.], 
+            initUfile=[init_U],
+            depthFile=[layers*400],
+            exe=test_executable,
+            wetMaskFile=[dbl_periodic_wetmask],
+                     nx=nx, ny=ny, dx=dx, dy=dy,
+                     dt = dt,
+                     dumpFreq = 200, diagFreq = dt,
+                     botDrag=botDrag,
+                     nTimeSteps=400)
+        else:
+            drv.simulate(initHfile=[400. for i in range(layers)], 
+            initUfile=[init_U for i in range(layers)],
+            depthFile=[layers*400],
+            exe=test_executable,
+            wetMaskFile=[dbl_periodic_wetmask],
+                     nx=nx, ny=ny, layers=layers, dx=dx, dy=dy,
+                     dt = dt,
+                     dumpFreq = 200, diagFreq = dt,
+                     botDrag=botDrag,
+                     nTimeSteps=400)
+
+        hfiles = sorted(glob.glob("output/snap.h.*"))
+        ufiles = sorted(glob.glob("output/snap.u.*"))
+        vfiles = sorted(glob.glob("output/snap.v.*"))
+
+
+        model_iteration = np.zeros(len(hfiles))
+
+        momentum = np.zeros(len(hfiles))
+        momentum_expected = np.zeros(len(hfiles))
+
+        volume = np.zeros(len(hfiles))
+
+        for counter,ufile in enumerate(ufiles):
+
+            h = aro.interpret_raw_file(hfiles[counter], nx, ny, layers)
+            u = aro.interpret_raw_file(ufile, nx, ny, layers)
+            v = aro.interpret_raw_file(vfiles[counter], nx, ny, layers)
+
+            model_iteration[counter] = float(ufile[-10:])
+
+            momentum[counter] = (nx * ny * dx * dy * rho0 * 
+                                    (np.mean(h[-1,:,:])*(np.mean(u[-1,:,:]) +
+                                                        np.mean(v[-1,:,:]))))
+
+
+        opt.assert_volume_conservation(nx, ny, layers, 1e-9)
+
+        init_h = 400
+        X, Y = np.meshgrid(grid.x, grid.yp1)
+        init_u = init_U(X, Y)
+
+
+        momentum_expected[:] = (nx * ny * dx * dy * rho0 * 
+                                (np.mean(init_h)*np.mean(init_u[:,:]))*
+                                    np.exp(-model_iteration*dt*botDrag))
+
+        test_passes = True
+
+        try:
+            np.testing.assert_allclose(momentum, momentum_expected, rtol=2e-3, atol=0)
+            return
+        except AssertionError as error:
+            test_passes = False
+
+            # plot output for visual inspection
+            plt.figure()
+            plt.plot(model_iteration*dt/(86400), momentum, '-', alpha=1,
+                    label='Simulated momentum')
+            plt.plot(model_iteration*dt/(86400), momentum_expected, '-', alpha=1,
+                    label='Expected momentum')
+            plt.legend()
+            plt.xlabel('Time (days)')
+            plt.ylabel('Momentum')
+            plt.savefig('f_plane_momentum_test.png', dpi=150)
+
+
+            plt.figure()
+            plt.plot(model_iteration,momentum/momentum_expected)
+            plt.xlabel('timestep')
+            plt.ylabel('simulated/expected')
+            plt.savefig('momentum_ratio.png')
+            plt.close()
+
+            plt.figure()
+            plt.plot(model_iteration*dt/(86400),
+                100.*(momentum - momentum_expected)/momentum_expected)
+            plt.xlabel('Time (days)')
+            plt.ylabel('percent error')
+            plt.ylim(-20,80)
+            plt.savefig('momentum_percent_error.png')
+            plt.close()
+
+        assert test_passes
+
+def test_f_plane_Hypre_botDrag_2Layers():
+    test_f_plane_Hypre_botDrag(botDrag=1e-5, layers=2)
+

--- a/test/botDrag_test.py
+++ b/test/botDrag_test.py
@@ -19,11 +19,6 @@ import sys
 sys.path.append(p.join(root_path, 'test'))
 import output_preservation_test as opt
 
-import subprocess as sub
-
-from builtins import int    # subclass of long on Py2
-
-
 def test_f_plane_Hypre_botDrag(botDrag=1e-5, layers=1):
 
     test_executable = "aronnax_external_solver_test"
@@ -83,8 +78,6 @@ def test_f_plane_Hypre_botDrag(botDrag=1e-5, layers=1):
 
         momentum = np.zeros(len(hfiles))
         momentum_expected = np.zeros(len(hfiles))
-
-        volume = np.zeros(len(hfiles))
 
         for counter,ufile in enumerate(ufiles):
 

--- a/test/bot_drag/aronnax.conf
+++ b/test/bot_drag/aronnax.conf
@@ -1,0 +1,63 @@
+# Aronnax configuration file. Change the values, but not the names.
+# 
+# au is viscosity
+# kh is thickness diffusivity
+# ar is linear drag between layers
+# dt is time step
+# slip is free-slip (=0), no-slip (=1), or partial slip (something in between)
+# nTimeSteps: number of timesteps before stopping
+# dumpFreq: frequency of snapshot output
+# avFreq: frequency of averaged output
+# hmin: minimum layer thickness allowed by model (for stability)
+# maxits: maximum iterations for the successive over relaxation algorithm. Should be at least max(nx,ny), and probably nx*ny
+# eps: convergence tolerance for SOR solver
+# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid. So far all tests using freesurfFac = 1. have failed 
+# g is the gravity at interfaces (including surface). must have as many entries as there are layers
+# input files are where to look for the various inputs
+
+[numerics]
+au = 0.
+kh = 0.0
+ar = 0e-8
+botDrag = 0e-6
+dt = 100.
+slip = 0.0
+nTimeSteps = 2001
+dumpFreq = 30000
+avFreq = 3e6
+hmin = 100
+maxits = 1000
+eps = 1e-7
+freesurfFac = 1.
+thickness_error = 1e-2
+
+[model]
+hmean = 400.
+H0 = 400.
+RedGrav = no
+
+[pressure_solver]
+nProcX = 1
+nProcY = 1
+
+[physics]
+g_vec = 9.8
+rho0 = 1035.
+
+[grid]
+nx = 100
+ny = 100
+layers = 1
+dx = 10e3
+dy = 10e3
+fUfile = :f_plane_f_u:0e-5
+fVfile = :f_plane_f_v:0e-5
+wetMaskFile = :rectangular_pool:
+
+# Inital conditions for h
+[initial_conditions]
+initHfile = :tracer_point_variable_3d:400.0
+
+[external_forcing]
+DumpWind = no
+RelativeWind = no


### PR DESCRIPTION
Fixes #193 by ensuring that bottom drag is applied in all n-layer simulations, even when n=1.

For posterity, the methodology was:
1. Build a test that identified the bug by failing when n=1, but not when n=2
2. Fix the bug.