### PR TITLE
Flush unused subroutine

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -5,6 +5,10 @@ Development
 Since latest release
 --------------------
 
+- Remove unused subroutine for enforcing minimum layer thickness `GH211 <https://github.com/edoddridge/aronnax/pull/211>`_ (9 March 2019)
+- Bug fix for bottom drag (didn't apply drag in one-layer simulations) `GH209 <https://github.com/edoddridge/aronnax/pull/209>`_ (9 March 2019)
+- Bug fix for open_mfdatarray, now respects variable location on C-grid `GH208 <https://github.com/edoddridge/aronnax/pull/208>`_ (21 December 2018)
+- Improved initial guess for external solver routine `GH206 <https://github.com/edoddridge/aronnax/pull/206>`_ (20 November 2018)
 - Python functions now have axis order specified by Comodo conventions `GH204 <https://github.com/edoddridge/aronnax/pull/204>`_ (13 July 2018)
 - Python wrapper can lazily load multiple timestamps into a 4D array (t,z,y,x) `GH204 <https://github.com/edoddridge/aronnax/pull/204>`_ (13 July 2018)
 - Aronnax paper published in Journal of Open Source Software (15 June 2018)

--- a/src/enforce_thickness.f90
+++ b/src/enforce_thickness.f90
@@ -33,35 +33,4 @@ module enforce_thickness
     return
   end subroutine enforce_depth_thickness_consistency
 
-  ! ---------------------------------------------------------------------------
-  !> Ensure that layer heights do not fall below the prescribed minimum
-
-  subroutine enforce_minimum_layer_thickness(hnew, hmin, nx, ny, layers, n)
-    implicit none
-
-    double precision, intent(inout) :: hnew(0:nx+1, 0:ny+1, layers)
-    double precision, intent(in) :: hmin
-    integer, intent(in) :: nx, ny, layers, n
-
-    integer counter, i, j, k
-
-    counter = 0
-
-    do k = 1, layers
-      do j = 1, ny
-        do i = 1, nx
-          if (hnew(i, j, k) .lt. hmin) then
-            hnew(i, j, k) = hmin
-            counter = counter + 1
-            if (counter .eq. 1) then
-              write(17, "(A, I0)") &
-                  "Layer thickness dropped below hmin at time step ", n
-            end if
-          end if
-        end do
-      end do
-    end do
-    return
-  end subroutine enforce_minimum_layer_thickness
-
 end module enforce_thickness

--- a/src/model_main.f90
+++ b/src/model_main.f90
@@ -300,10 +300,6 @@ module model_main
 
       end if
 
-
-      ! Stop layers from getting too thin
-      ! call enforce_minimum_layer_thickness(h_new, hmin, nx, ny, layers, n)
-
       ! Wrap fields around for periodic simulations
       call wrap_fields_3D(u_new, nx, ny, layers)
       call wrap_fields_3D(v_new, nx, ny, layers)


### PR DESCRIPTION
The subroutine to enforce minimum layer thickness is no longer used or tested - it should be removed.