### PR TITLE
Checkpoint bugfix

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -5,7 +5,7 @@ Development
 Since latest release
 --------------------
 
-
+- Checkpointing bugfix. Subroutine was using global array indicies for local array `GH214 <https://github.com/edoddridge/aronnax/pull/214>`_ (12 March 2019)
 
 Version 0.3.0 (12 March 2019)
 --------------------------------

--- a/src/io.f90
+++ b/src/io.f90
@@ -416,7 +416,7 @@ module io
                         n, name, num_procs, myid)
     implicit none
 
-    double precision, intent(in) :: array(1-OL:nx+OL, 1-OL:ny+OL, layers, AB_order)
+    double precision, intent(in) :: array(xlow-OL:xhigh+OL, ylow-OL:yhigh+OL, layers, AB_order)
     integer,          intent(in) :: nx, ny, layers
     integer,          intent(in) :: ilower(0:num_procs-1,2)
     integer,          intent(in) :: iupper(0:num_procs-1,2)

--- a/test/output_preservation_test.py
+++ b/test/output_preservation_test.py
@@ -140,6 +140,28 @@ def test_gaussian_bump_red_grav():
         assert_volume_conservation(10, 10, 1, 1e-5)
         # assert_diagnostics_similar(['h', 'u', 'v'], 1e-10)
 
+def test_gaussian_bump_red_grav_continuation_of_single_core_MPI_2X():
+    xlen = 1e6
+    ylen = 1e6
+    with working_directory(p.join(self_path, "beta_plane_bump_red_grav")):
+        drv.simulate(initHfile=[bump], exe=test_executable,
+                     nx=10, ny=10, dx=xlen/10, dy=ylen/10,
+                     niter0=101, nTimeSteps=400, nProcX=2)
+        assert_outputs_close(10, 10, 1, 1.5e-13)
+        assert_volume_conservation(10, 10, 1, 1e-5)
+        assert_diagnostics_similar(['h', 'u', 'v'], 1e-10)
+
+
+def test_gaussian_bump_red_grav_MPI_2X():
+    xlen = 1e6
+    ylen = 1e6
+    with working_directory(p.join(self_path, "beta_plane_bump_red_grav")):
+        drv.simulate(initHfile=[bump], exe=test_executable,
+                     nx=10, ny=10, dx=xlen/10, dy=ylen/10,
+                     nProcX=2)
+        assert_outputs_close(10, 10, 1, 1.5e-13)
+        assert_volume_conservation(10, 10, 1, 1e-5)
+        # assert_diagnostics_similar(['h', 'u', 'v'], 1e-10)
 
 def test_gaussian_bump_red_grav_continuation_MPI_2X():
     xlen = 1e6


### PR DESCRIPTION
The subroutine for writing checkpoints was using global indices for the local array. The tests didn't catch it because they didn't try restarting from a multicore simulation. New tests have been added that detect this bug, and it has been fixed.