### PR TITLE
bold on f and zeta since they are  vectors

### DIFF
--- a/docs/aronnax_model.rst
+++ b/docs/aronnax_model.rst
@@ -60,10 +60,10 @@ in which :math:`\mathbf{f}` is the Coriolis parameter, and :math:`g^{'}` is the 
 This can be rewritten in terms of the Bernoulli Potential to give,
 
 .. math::
-    \frac{\partial\mathbf{v_{n}}}{\partial t} + (f+\zeta_{n}) \times \mathbf{v_{n}} + \nabla \Pi_{n} + = \kappa \nabla^{2} \mathbf{v_{n}} + \frac{\mathbf{F_{n}}}{\rho_{0}}
+    \frac{\partial\mathbf{v_{n}}}{\partial t} + (\mathbf{f}+\boldsymbol{\zeta_{n}}) \times \mathbf{v_{n}} + \nabla \Pi_{n} + = \kappa \nabla^{2} \mathbf{v_{n}} + \frac{\mathbf{F_{n}}}{\rho_{0}}
     :name: eqn_momentum_Bernoulli_form
 
-where :math:`\zeta_{n}` is the relative vorticity in layer :math:`n`, :math:`\Pi_{n}` is the Bernoulli potential in layer :math:`n` defined as :math:`\left(\mathbf{v_{n}}\cdot\mathbf{v_{n}}\right)/2 + p/\rho_{0}` in which :math:`p` is the hydrostatic pressure, and :math:`\kappa` is the viscosity. In this form the non-linearity from the material derivative has been moved into the Bernoulli Potential and the vorticity term. 
+where :math:`\boldsymbol{\zeta_{n}}` is the relative vorticity in layer :math:`n`, :math:`\Pi_{n}` is the Bernoulli potential in layer :math:`n` defined as :math:`\left(\mathbf{v_{n}}\cdot\mathbf{v_{n}}\right)/2 + p/\rho_{0}` in which :math:`p` is the hydrostatic pressure, and :math:`\kappa` is the viscosity. In this form the non-linearity from the material derivative has been moved into the Bernoulli Potential and the vorticity term.
 
 
 The model can be used in either reduced gravity mode, with a quiescent abyss, or in n-layer mode with bathymetry. In the n-layer case the model can either be run with a rigid lid, or with a free surface. In n-layer simulations the following equation is also solved
@@ -134,7 +134,7 @@ at depth :math:`z` is
 
 .. math::
   P_{1}\left(x,y,z,t\right) = P\left(x,y,t\right) - \rho_{1}gz,
-  :name: eqn_reduced_grav_layer_1_pressure 
+  :name: eqn_reduced_grav_layer_1_pressure
 
 where :math:`\rho_{1}` is the density of the upper layer, :math:`z` is
 the vertical coordinate which becomes more negative with depth. A
@@ -145,7 +145,7 @@ interface displacement. The pressure in layer 2 is given by
 
 .. math::
     P_{2}(x,y,z,t) = P_{1}(x,y,h,t) - \rho_{2}g(z+h) = P + \rho_{1}gh + \rho_{2}g(z+h),
-    :name: eqn_reduced_grav_layer_2_pressure 
+    :name: eqn_reduced_grav_layer_2_pressure
 
 where :math:`h` is the thickness of the upper layer. Since a central
 assumption of the reduced gravity framework is that the horizontal
@@ -156,13 +156,13 @@ zero gives
 
 .. math::
     0 = \mathbf{\nabla} P + \mathbf{\nabla}\rho_{1}gh + \mathbf{\nabla}\rho_{2}g(-h),
-    :name: eqn_reduced_grav_pressure_grad_proto 
+    :name: eqn_reduced_grav_pressure_grad_proto
 
 which can be rearranged to give
 
 .. math::
     \mathbf{\nabla}P = g(\rho_{2} - \rho_{1}) \mathbf{\nabla}h,
-    :name: `eqn_reduced_grav_pressure_grad 
+    :name: `eqn_reduced_grav_pressure_grad
 
 which relates the horizontal pressure gradients in the upper layer to
 displacements of the interface. The momentum equation for the upper
@@ -170,7 +170,7 @@ layer is therefore
 
 .. math::
     \frac{D\mathbf{V}}{Dt} +  \mathbf{f} \times \mathbf{V} + g^{'}\mathbf{\nabla}h = \mathbf{F},
-    :name: eqn_reduced_grav_layer_1_momentum 
+    :name: eqn_reduced_grav_layer_1_momentum
 
 in which :math:`g^{'}` is the reduced gravity given by
 :math:`{g(\rho_{2} - \rho_{1})}/{\rho_{1}}`. The reduced gravity is
@@ -203,28 +203,28 @@ Aronnax is discretised on an Arakawa C-grid, with the velocity and thickness var
 The choice of quiescent abyss or n-layer physics is made by a runtime parameter in the input file. The numerical algorithm for calculating the values at the next time level, :math:`n+1`, is as follows:
 
   - The Bernoulli Potential is calculated using values from time-level :math:`n`
-  
+
     - The function used depends on whether the model is running in reduced gravity mode or n-layer mode
-  
+
   - The relative vorticity is calculated using values from time-level :math:`n`
   - The layer thickness tendencies are calculated using the velocities and layer thicknesses from time-level :math:`n`
   - the velocity tendencies are calculated using values from time-level :math:`n`
   - the layer thicknesses and velocities are stepped forward in time to :math:`n+1` using a third-order Adams-Bashforth algorithm and the stored time derivatives from the previous two timesteps. N.B. for the n-layer version these velocities are not strictly at time :math:`n+1`, let's call it time level :math:`n+*`.
   - For the n-layer version:
-  
+
     - The no-normal flow boundary condition is applied (perhaps unnecessary?)
     - The barotropic velocity required to keep the vertically integrated flow non-divergent in the horizontal is calculated and added to the baroclinic velocities calculated previously. To do this:
-    
+
       - the barotropic velocities are calculated from the velocities at time-level :math:`n+*`.
       - the divergence of these velocities is used to solve for the free surface elevation at time-level :math:`n+1` that makes the barotropic flow non-divergent
-      
+
         - This is the step that requires the linear system solve, since we solve the equation implicitly to sidestep the issue of requiring a *very* short :math:`\delta t`.
-      
-      
+
+
       - the barotropic correction is applied to the velocity fields
       - consistency between the sum of the layer thicknesses and the depth of the ocean is forced by applying a uniform inflation/deflation to the layers. (the model currently prints a warning if the discrepancy is larger than a configurable threshold, which defaults to 1\%)
-    
-  
+
+
   - The no normal flow and tangential (no-slip or free-slip) boundary conditions are applied
   - The layer thicnkesses are forced to be larger than a configurable minimum. This is for numerical stability and is probably only necessary for the layer receiving the wind forcing. This is discussed in ticket `#26 <https://github.com/edoddridge/aronnax/issues/26>`_
   - the arrays are shuffled to prepare for the next timestep.


### PR DESCRIPTION
I made f and zeta bold.
(\mathbf has no effect on greek letters so I used \boldsymbol)

One remark: why `g^{'}` and not simply `g'`? The prime gets rendered so high up with `^{'}`.

@edoddridge: Note that this PR is to be merged on your `doc-fixes` branch. Also, I only changed lines 63, 66. All other changes below must have to do with how are text editors handle line breaks. (It's been puzzling me long e.g. when interacting with @glwagner; if you have any idea why that happens let me know..)