### PR TITLE
Open mfdataarray bigfix

### DIFF
--- a/aronnax/core.py
+++ b/aronnax/core.py
@@ -155,7 +155,7 @@ def interpret_raw_file_delayed(name, nx, ny, layers, dx, dy):
     variable_name = '.'.join(variable_name.split('.')[:-1])
 
     d = dsa.from_delayed(delayed(interpret_raw_file)(name, nx, ny, layers),
-                            (layers, ny+dy, nx+dx), float, name=variable_name)
+                            (layers, ny+dy, nx+dx), float)
     return d
 
 

--- a/aronnax/core.py
+++ b/aronnax/core.py
@@ -151,8 +151,6 @@ def interpret_raw_file_delayed(name, nx, ny, layers, dx, dy):
     Use Dask.delayed to lazily load a single output file. While this can be
     used as is, it is intended to be an internal function called by `open_mfdataset`.
     """
-    variable_name = p.basename(name)
-    variable_name = '.'.join(variable_name.split('.')[:-1])
 
     d = dsa.from_delayed(delayed(interpret_raw_file)(name, nx, ny, layers),
                             (layers, ny+dy, nx+dx), float)

--- a/aronnax/core.py
+++ b/aronnax/core.py
@@ -197,31 +197,31 @@ def open_mfdataarray(files, grid):
 
     if dx ==1 and dy == 1:
         # variable at vorticity location
-        ds = xr.DataArray(ds, coords=dict(time=timestamps,
+        ds = xr.DataArray(ds, coords=dict(iter=timestamps,
                                         layers=np.arange(layers),
                                         yp1=grid.yp1, xp1=grid.xp1),
-                        dims=['time','layers','yp1','xp1'],
+                        dims=['iter','layers','yp1','xp1'],
                         name=output_variables[0])
     elif dx == 1:
         # variable at u location
-        ds = xr.DataArray(ds, coords=dict(time=timestamps,
+        ds = xr.DataArray(ds, coords=dict(iter=timestamps,
                                         layers=np.arange(layers),
                                         y=grid.y, xp1=grid.xp1),
-                        dims=['time','layers','y','xp1'],
+                        dims=['iter','layers','y','xp1'],
                         name=output_variables[0])
     elif dy == 1:
         # variable at v location
-        ds = xr.DataArray(ds, coords=dict(time=timestamps,
+        ds = xr.DataArray(ds, coords=dict(iter=timestamps,
                                         layers=np.arange(layers),
                                         yp1=grid.yp1, x=grid.x),
-                        dims=['time','layers','yp1','x'],
+                        dims=['iter','layers','yp1','x'],
                         name=output_variables[0])
     elif dx == 0 and dy ==0:
         # variable at h location
-        ds = xr.DataArray(ds, coords=dict(time=timestamps,
+        ds = xr.DataArray(ds, coords=dict(iter=timestamps,
                                         layers=np.arange(layers),
                                         y=grid.y, x=grid.x),
-                        dims=['time','layers','y','x'],
+                        dims=['iter','layers','y','x'],
                         name=output_variables[0])
     else:
         # not able to determine where we are

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -5,6 +5,10 @@ Development
 Since latest release
 --------------------
 
+- open_mfdataarray bugfix. Was loading copies of last array, now loads all timestamps as expected `GH223 <https://github.com/edoddridge/aronnax/pull/223>`_ (20 March 2019)
+- Halos. Improve parallel performance by making better use of tile halos to reduce number of exchange calls `GH220 <https://github.com/edoddridge/aronnax/pull/220>`_ (14 March 2019)
+- Benchmarking. Add figure with runtime for 1.5 and 2 layer configurations on 1-64 processors `GH216 <https://github.com/edoddridge/aronnax/pull/216>`_ (13 March 2019)
+- Docs improvements by @navidcy and @edoddridge `GH215 <https://github.com/edoddridge/aronnax/pull/215>`_ and GH217 <https://github.com/edoddridge/aronnax/pull/217>`_ (13 March 2019)
 - Checkpointing bugfix. Subroutine was using global array indicies for local array `GH214 <https://github.com/edoddridge/aronnax/pull/214>`_ (12 March 2019)
 
 Version 0.3.0 (12 March 2019)

--- a/test/read_output_test.py
+++ b/test/read_output_test.py
@@ -17,7 +17,7 @@ self_path = p.dirname(p.abspath(__file__))
 
 
 def test_open_mfdataarray_u_location():
-    '''Open a number of files and assert that the length of the time
+    '''Open a number of files and assert that the length of the iter
         dimension is the same as the number of files, and that the
         correct x and y variables have been used.'''
 
@@ -32,12 +32,12 @@ def test_open_mfdataarray_u_location():
         output_files = glob.glob('output/snap.u*')
         ds = aro.open_mfdataarray(output_files, grid)
 
-        assert len(output_files) == ds.time.shape[0]
+        assert len(output_files) == ds.iter.shape[0]
         assert nx+1 == ds.xp1.shape[0]
         assert ny == ds.y.shape[0]
 
 def test_open_mfdataarray_v_location():
-    '''Open a number of files and assert that the length of the time
+    '''Open a number of files and assert that the length of the iter
         dimension is the same as the number of files, and that the
         correct x and y variables have been used.'''
 
@@ -52,12 +52,12 @@ def test_open_mfdataarray_v_location():
         output_files = glob.glob('output/snap.v*')
         ds = aro.open_mfdataarray(output_files, grid)
 
-        assert len(output_files) == ds.time.shape[0]
+        assert len(output_files) == ds.iter.shape[0]
         assert nx == ds.x.shape[0]
         assert ny+1 == ds.yp1.shape[0]
 
 def test_open_mfdataarray_h_location():
-    '''Open a number of files and assert that the length of the time
+    '''Open a number of files and assert that the length of the iter
         dimension is the same as the number of files, and that the
         correct x and y variables have been used.'''
 
@@ -71,7 +71,7 @@ def test_open_mfdataarray_h_location():
         output_files = glob.glob('output/snap.h*')
         ds = aro.open_mfdataarray(output_files, grid)
 
-        assert len(output_files) == ds.time.shape[0]
+        assert len(output_files) == ds.iter.shape[0]
         assert nx == ds.x.shape[0]
         assert ny == ds.y.shape[0]
     


### PR DESCRIPTION
Fixe the bug identified in #222.

Rename 'time' to 'iter' since it doesn't represent model time, but actually represents iteration number from the main integration loop.