### PR TITLE
Doc tweaks

### DIFF
--- a/benchmarks/beta_plane_bump/aronnax.conf
+++ b/benchmarks/beta_plane_bump/aronnax.conf
@@ -11,7 +11,7 @@
 # hmin: minimum layer thickness allowed by model (for stability)
 # maxits: maximum iterations for the successive over relaxation algorithm. Should be at least max(nx,ny), and probably nx*ny
 # eps: convergence tolerance for SOR solver
-# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid. So far all tests using freesurfFac = 1. have failed 
+# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid.
 # g is the gravity at interfaces (including surface). must have as many entries as there are layers
 # input files are where to look for the various inputs
 

--- a/benchmarks/beta_plane_bump_red_grav/aronnax.conf
+++ b/benchmarks/beta_plane_bump_red_grav/aronnax.conf
@@ -11,7 +11,7 @@
 # hmin: minimum layer thickness allowed by model (for stability)
 # maxits: maximum iterations for the successive over relaxation algorithm. Should be at least max(nx,ny), and probably nx*ny
 # eps: convergence tolerance for SOR solver
-# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid. So far all tests using freesurfFac = 1. have failed 
+# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid.
 # g is the gravity at interfaces (including surface). must have as many entries as there are layers
 # input files are where to look for the various inputs
 

--- a/docs/aronnax_model.rst
+++ b/docs/aronnax_model.rst
@@ -1,6 +1,8 @@
 The Aronnax Model
 ********************
 
+Aronnax is a highly idealised model for simulating large-scale (100-1000km) flows in the ocean. Aronnax is intended for theoretical and empirical oceanographers, as a (relatively) fast and easy-to-use simulation model, bridging the gap between pencil-and-paper on one hand, and more faithful (and complex) computational models on the other. The numerical core is written in Fortran to improve performance, and wrapped in Python to improve usability. The model domain can be closed at the edges, or may bhorizontally periodic in one or two dimensions, and may include arbitrary bathymetry. This flexibility makes Aronnax a useful tool for theoretical physical oceanographers.
+
 The Physics
 ============
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -16,9 +16,11 @@ The Python components of Aronnax depend on
 
 | :bash:`numpy`
 | :bash:`scipy`
+| :bash:`tools`
+| :bash:`future`
 |
 
-We recommend installing these with your favourite package manager before installing Aronnax. While the previous dependencies will allow you to run the model, some of the functions for dealing with the output files also depend on
+The final two are required for Python 2/3 compatibility. We recommend installing these with your favourite package manager before installing Aronnax. While the previous dependencies will allow you to run the model, some of the functions for dealing with the output files also depend on
 
 | :bash:`xarray`
 | :bash:`dask`

--- a/docs/running_aronnax.rst
+++ b/docs/running_aronnax.rst
@@ -85,7 +85,7 @@ This parameter allows a simulation to be restarted from the given timestep. It r
 
 wetMaskFile
 -----------
-The wetmask defines which grid points within the computational domain contain fluid. The wetmask is defined on the tracer points, and a value of 1 defines fluid, while a value of 0 defines land. The domain is doubly periodic in `x` and `y` by default. To produce a closed domain the wetmaks should be set to 0 along the edges of the domain. To close the domain it is sufficient to place a strip of land along either the northern or southern boundary and either the western or eastern boundary. You may find it conceptually easier to close both edges.
+The wetmask defines which grid points within the computational domain contain fluid. The wetmask is defined on the tracer points, and a value of 1 defines fluid, while a value of 0 defines land. The domain is doubly periodic in `x` and `y` by default. To produce a closed domain the wetmask should be set to 0 along the edges of the domain. Placing a barrier at either the southern or the northern boundary will remove periodicity in the meridional direction. Similarly, a barrier along either the eastern or western boundary will prevent the model from being periodic in the zonal direction.
 
 RelativeWind
 ------------

--- a/examples/n_layer/beta_plane_bump/aronnax.conf
+++ b/examples/n_layer/beta_plane_bump/aronnax.conf
@@ -11,7 +11,7 @@
 # hmin: minimum layer thickness allowed by model (for stability)
 # maxits: maximum iterations for the successive over relaxation algorithm. Should be at least max(nx,ny), and probably nx*ny
 # eps: convergence tolerance for SOR solver
-# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid. So far all tests using freesurfFac = 1. have failed 
+# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid.
 # g is the gravity at interfaces (including surface). must have as many entries as there are layers
 # input files are where to look for the various inputs
 

--- a/examples/n_layer/beta_plane_gyre/aronnax.conf
+++ b/examples/n_layer/beta_plane_gyre/aronnax.conf
@@ -11,7 +11,7 @@
 # hmin: minimum layer thickness allowed by model (for stability)
 # maxits: maximum iterations for the successive over relaxation algorithm. Should be at least max(nx,ny), and probably nx*ny
 # eps: convergence tolerance for SOR solver
-# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid. So far all tests using freesurfFac = 1. have failed 
+# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid.
 # g is the gravity at interfaces (including surface). must have as many entries as there are layers
 # input files are where to look for the various inputs
 

--- a/examples/reduced_gravity/beta_plane_bump/aronnax.conf
+++ b/examples/reduced_gravity/beta_plane_bump/aronnax.conf
@@ -11,7 +11,7 @@
 # hmin: minimum layer thickness allowed by model (for stability)
 # maxits: maximum iterations for the successive over relaxation algorithm. Should be at least max(nx,ny), and probably nx*ny
 # eps: convergence tolerance for SOR solver
-# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid. So far all tests using freesurfFac = 1. have failed
+# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid.
 # g is the gravity at interfaces (including surface). must have as many entries as there are layers
 # input files are where to look for the various inputs
 

--- a/examples/reduced_gravity/beta_plane_gyre/aronnax.conf
+++ b/examples/reduced_gravity/beta_plane_gyre/aronnax.conf
@@ -11,7 +11,7 @@
 # hmin: minimum layer thickness allowed by model (for stability)
 # maxits: maximum iterations for the successive over relaxation algorithm. Should be at least max(nx,ny), and probably nx*ny
 # eps: convergence tolerance for SOR solver
-# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid. So far all tests using freesurfFac = 1. have failed 
+# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid.
 # g is the gravity at interfaces (including surface). must have as many entries as there are layers
 # input files are where to look for the various inputs
 

--- a/reproductions/Davis_et_al_2014/control/aronnax.conf
+++ b/reproductions/Davis_et_al_2014/control/aronnax.conf
@@ -11,7 +11,7 @@
 # hmin: minimum layer thickness allowed by model (for stability)
 # maxits: maximum iterations for the successive over relaxation algorithm. Should be at least max(nx,ny), and probably nx*ny
 # eps: convergence tolerance for SOR solver
-# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid. So far all tests using freesurfFac = 1. have failed 
+# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid.
 # g is the gravity at interfaces (including surface). must have as many entries as there are layers
 # input files are where to look for the various inputs
 

--- a/reproductions/Davis_et_al_2014/control_final_five/aronnax.conf
+++ b/reproductions/Davis_et_al_2014/control_final_five/aronnax.conf
@@ -11,7 +11,7 @@
 # hmin: minimum layer thickness allowed by model (for stability)
 # maxits: maximum iterations for the successive over relaxation algorithm. Should be at least max(nx,ny), and probably nx*ny
 # eps: convergence tolerance for SOR solver
-# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid. So far all tests using freesurfFac = 1. have failed 
+# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid.
 # g is the gravity at interfaces (including surface). must have as many entries as there are layers
 # input files are where to look for the various inputs
 

--- a/reproductions/Yang_et_al_2016/spin_up/aronnax.conf
+++ b/reproductions/Yang_et_al_2016/spin_up/aronnax.conf
@@ -11,7 +11,7 @@
 # hmin: minimum layer thickness allowed by model (for stability)
 # maxits: maximum iterations for the successive over relaxation algorithm. Should be at least max(nx,ny), and probably nx*ny
 # eps: convergence tolerance for SOR solver
-# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid. So far all tests using freesurfFac = 1. have failed 
+# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid.
 # g is the gravity at interfaces (including surface). must have as many entries as there are layers
 # input files are where to look for the various inputs
 
@@ -37,7 +37,7 @@ thickness_error = 1e-2
 debug_level = 0
 
 [pressure_solver]
-nProcX = 1
+nProcX = 2
 nProcY = 1
 
 [model]

--- a/test/beta_plane_bump/aronnax.conf
+++ b/test/beta_plane_bump/aronnax.conf
@@ -11,7 +11,7 @@
 # hmin: minimum layer thickness allowed by model (for stability)
 # maxits: maximum iterations for the successive over relaxation algorithm. Should be at least max(nx,ny), and probably nx*ny
 # eps: convergence tolerance for SOR solver
-# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid. So far all tests using freesurfFac = 1. have failed 
+# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid.
 # g is the gravity at interfaces (including surface). must have as many entries as there are layers
 # input files are where to look for the various inputs
 

--- a/test/beta_plane_bump_debug_test/aronnax.conf
+++ b/test/beta_plane_bump_debug_test/aronnax.conf
@@ -11,7 +11,7 @@
 # hmin: minimum layer thickness allowed by model (for stability)
 # maxits: maximum iterations for the successive over relaxation algorithm. Should be at least max(nx,ny), and probably nx*ny
 # eps: convergence tolerance for SOR solver
-# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid. So far all tests using freesurfFac = 1. have failed 
+# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid.
 # g is the gravity at interfaces (including surface). must have as many entries as there are layers
 # input files are where to look for the various inputs
 

--- a/test/beta_plane_bump_red_grav/aronnax.conf
+++ b/test/beta_plane_bump_red_grav/aronnax.conf
@@ -11,7 +11,7 @@
 # hmin: minimum layer thickness allowed by model (for stability)
 # maxits: maximum iterations for the successive over relaxation algorithm. Should be at least max(nx,ny), and probably nx*ny
 # eps: convergence tolerance for SOR solver
-# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid. So far all tests using freesurfFac = 1. have failed
+# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid.
 # g is the gravity at interfaces (including surface). must have as many entries as there are layers
 # input files are where to look for the various inputs
 

--- a/test/beta_plane_bump_red_grav_debug_test/aronnax.conf
+++ b/test/beta_plane_bump_red_grav_debug_test/aronnax.conf
@@ -11,7 +11,7 @@
 # hmin: minimum layer thickness allowed by model (for stability)
 # maxits: maximum iterations for the successive over relaxation algorithm. Should be at least max(nx,ny), and probably nx*ny
 # eps: convergence tolerance for SOR solver
-# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid. So far all tests using freesurfFac = 1. have failed
+# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid.
 # g is the gravity at interfaces (including surface). must have as many entries as there are layers
 # input files are where to look for the various inputs
 

--- a/test/beta_plane_gyre/aronnax.conf
+++ b/test/beta_plane_gyre/aronnax.conf
@@ -11,7 +11,7 @@
 # hmin: minimum layer thickness allowed by model (for stability)
 # maxits: maximum iterations for the successive over relaxation algorithm. Should be at least max(nx,ny), and probably nx*ny
 # eps: convergence tolerance for SOR solver
-# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid. So far all tests using freesurfFac = 1. have failed 
+# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid.
 # g is the gravity at interfaces (including surface). must have as many entries as there are layers
 # input files are where to look for the various inputs
 

--- a/test/beta_plane_gyre_free_surf/aronnax.conf
+++ b/test/beta_plane_gyre_free_surf/aronnax.conf
@@ -11,7 +11,7 @@
 # hmin: minimum layer thickness allowed by model (for stability)
 # maxits: maximum iterations for the successive over relaxation algorithm. Should be at least max(nx,ny), and probably nx*ny
 # eps: convergence tolerance for SOR solver
-# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid. So far all tests using freesurfFac = 1. have failed 
+# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid.
 # g is the gravity at interfaces (including surface). must have as many entries as there are layers
 # input files are where to look for the various inputs
 

--- a/test/beta_plane_gyre_free_surf_hypre/aronnax.conf
+++ b/test/beta_plane_gyre_free_surf_hypre/aronnax.conf
@@ -11,7 +11,7 @@
 # hmin: minimum layer thickness allowed by model (for stability)
 # maxits: maximum iterations for the successive over relaxation algorithm. Should be at least max(nx,ny), and probably nx*ny
 # eps: convergence tolerance for SOR solver
-# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid. So far all tests using freesurfFac = 1. have failed 
+# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid.
 # g is the gravity at interfaces (including surface). must have as many entries as there are layers
 # input files are where to look for the various inputs
 

--- a/test/beta_plane_gyre_red_grav/aronnax.conf
+++ b/test/beta_plane_gyre_red_grav/aronnax.conf
@@ -11,7 +11,7 @@
 # hmin: minimum layer thickness allowed by model (for stability)
 # maxits: maximum iterations for the successive over relaxation algorithm. Should be at least max(nx,ny), and probably nx*ny
 # eps: convergence tolerance for SOR solver
-# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid. So far all tests using freesurfFac = 1. have failed 
+# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid.
 # g is the gravity at interfaces (including surface). must have as many entries as there are layers
 # input files are where to look for the various inputs
 

--- a/test/bot_drag/aronnax.conf
+++ b/test/bot_drag/aronnax.conf
@@ -11,7 +11,7 @@
 # hmin: minimum layer thickness allowed by model (for stability)
 # maxits: maximum iterations for the successive over relaxation algorithm. Should be at least max(nx,ny), and probably nx*ny
 # eps: convergence tolerance for SOR solver
-# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid. So far all tests using freesurfFac = 1. have failed 
+# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid.
 # g is the gravity at interfaces (including surface). must have as many entries as there are layers
 # input files are where to look for the various inputs
 

--- a/test/f_plane/aronnax.conf
+++ b/test/f_plane/aronnax.conf
@@ -11,7 +11,7 @@
 # hmin: minimum layer thickness allowed by model (for stability)
 # maxits: maximum iterations for the successive over relaxation algorithm. Should be at least max(nx,ny), and probably nx*ny
 # eps: convergence tolerance for SOR solver
-# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid. So far all tests using freesurfFac = 1. have failed 
+# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid.
 # g is the gravity at interfaces (including surface). must have as many entries as there are layers
 # input files are where to look for the various inputs
 

--- a/test/f_plane_red_grav/aronnax.conf
+++ b/test/f_plane_red_grav/aronnax.conf
@@ -11,7 +11,7 @@
 # hmin: minimum layer thickness allowed by model (for stability)
 # maxits: maximum iterations for the successive over relaxation algorithm. Should be at least max(nx,ny), and probably nx*ny
 # eps: convergence tolerance for SOR solver
-# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid. So far all tests using freesurfFac = 1. have failed 
+# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid.
 # g is the gravity at interfaces (including surface). must have as many entries as there are layers
 # input files are where to look for the various inputs
 

--- a/test/outcropping/aronnax.conf
+++ b/test/outcropping/aronnax.conf
@@ -11,7 +11,7 @@
 # hmin: minimum layer thickness allowed by model (for stability)
 # maxits: maximum iterations for the successive over relaxation algorithm. Should be at least max(nx,ny), and probably nx*ny
 # eps: convergence tolerance for SOR solver
-# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid. So far all tests using freesurfFac = 1. have failed 
+# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid.
 # g is the gravity at interfaces (including surface). must have as many entries as there are layers
 # input files are where to look for the various inputs
 

--- a/test/periodic_BC/aronnax.conf
+++ b/test/periodic_BC/aronnax.conf
@@ -11,7 +11,7 @@
 # hmin: minimum layer thickness allowed by model (for stability)
 # maxits: maximum iterations for the successive over relaxation algorithm. Should be at least max(nx,ny), and probably nx*ny
 # eps: convergence tolerance for SOR solver
-# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid. So far all tests using freesurfFac = 1. have failed 
+# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid.
 # g is the gravity at interfaces (including surface). must have as many entries as there are layers
 # input files are where to look for the various inputs
 

--- a/test/periodic_BC_red_grav/aronnax.conf
+++ b/test/periodic_BC_red_grav/aronnax.conf
@@ -11,7 +11,7 @@
 # hmin: minimum layer thickness allowed by model (for stability)
 # maxits: maximum iterations for the successive over relaxation algorithm. Should be at least max(nx,ny), and probably nx*ny
 # eps: convergence tolerance for SOR solver
-# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid. So far all tests using freesurfFac = 1. have failed 
+# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid.
 # g is the gravity at interfaces (including surface). must have as many entries as there are layers
 # input files are where to look for the various inputs
 

--- a/test/physics_tests/f_plane_n_layer_init_u/aronnax.conf
+++ b/test/physics_tests/f_plane_n_layer_init_u/aronnax.conf
@@ -11,7 +11,7 @@
 # hmin: minimum layer thickness allowed by model (for stability)
 # maxits: maximum iterations for the successive over relaxation algorithm. Should be at least max(nx,ny), and probably nx*ny
 # eps: convergence tolerance for SOR solver
-# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid. So far all tests using freesurfFac = 1. have failed 
+# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid.
 # g is the gravity at interfaces (including surface). must have as many entries as there are layers
 # input files are where to look for the various inputs
 

--- a/test/physics_tests/f_plane_n_layer_wind/aronnax.conf
+++ b/test/physics_tests/f_plane_n_layer_wind/aronnax.conf
@@ -11,7 +11,7 @@
 # hmin: minimum layer thickness allowed by model (for stability)
 # maxits: maximum iterations for the successive over relaxation algorithm. Should be at least max(nx,ny), and probably nx*ny
 # eps: convergence tolerance for SOR solver
-# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid. So far all tests using freesurfFac = 1. have failed 
+# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid.
 # g is the gravity at interfaces (including surface). must have as many entries as there are layers
 # input files are where to look for the various inputs
 

--- a/test/physics_tests/f_plane_red_grav_init_u/aronnax.conf
+++ b/test/physics_tests/f_plane_red_grav_init_u/aronnax.conf
@@ -11,7 +11,7 @@
 # hmin: minimum layer thickness allowed by model (for stability)
 # maxits: maximum iterations for the successive over relaxation algorithm. Should be at least max(nx,ny), and probably nx*ny
 # eps: convergence tolerance for SOR solver
-# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid. So far all tests using freesurfFac = 1. have failed 
+# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid.
 # g is the gravity at interfaces (including surface). must have as many entries as there are layers
 # input files are where to look for the various inputs
 

--- a/test/physics_tests/f_plane_red_grav_wind/aronnax.conf
+++ b/test/physics_tests/f_plane_red_grav_wind/aronnax.conf
@@ -11,7 +11,7 @@
 # hmin: minimum layer thickness allowed by model (for stability)
 # maxits: maximum iterations for the successive over relaxation algorithm. Should be at least max(nx,ny), and probably nx*ny
 # eps: convergence tolerance for SOR solver
-# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid. So far all tests using freesurfFac = 1. have failed 
+# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid.
 # g is the gravity at interfaces (including surface). must have as many entries as there are layers
 # input files are where to look for the various inputs
 

--- a/test/relative_wind/aronnax.conf
+++ b/test/relative_wind/aronnax.conf
@@ -11,7 +11,7 @@
 # hmin: minimum layer thickness allowed by model (for stability)
 # maxits: maximum iterations for the successive over relaxation algorithm. Should be at least max(nx,ny), and probably nx*ny
 # eps: convergence tolerance for SOR solver
-# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid. So far all tests using freesurfFac = 1. have failed 
+# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid.
 # g is the gravity at interfaces (including surface). must have as many entries as there are layers
 # input files are where to look for the various inputs
 

--- a/test/vertical_diffusion/aronnax.conf
+++ b/test/vertical_diffusion/aronnax.conf
@@ -12,7 +12,7 @@
 # hmin: minimum layer thickness allowed by model (for stability)
 # maxits: maximum iterations for the successive over relaxation algorithm. Should be at least max(nx,ny), and probably nx*ny
 # eps: convergence tolerance for SOR solver
-# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid. So far all tests using freesurfFac = 1. have failed 
+# freesurfFac: 1. = linear implicit free surface, 0. = rigid lid.
 # g is the gravity at interfaces (including surface). must have as many entries as there are layers
 # input files are where to look for the various inputs
 


### PR DESCRIPTION
Three small changes to the docs.

Removed comments in `aronnax.conf` files about runs with the free surface failing. That comment was out of date.

Added `tools` and `future` to the list of dependencies, which closes #224.

Modified, and hopefully improved, description of periodic boundary conditions, which closes #203.
