### PR TITLE
Update hypre repo url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "lib/hypre"]
 	path = lib/hypre
-	url = https://github.com/LLNL/hypre.git
+	url = https://github.com/hypre-space/hypre
+


### PR DESCRIPTION
As described in #228, the repo url for hypre doesn't work. This PR replaces the old url with a new one.

closes #228 