### PR TITLE
Add gcov to get fortran code coverage

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -49,11 +49,15 @@ jobs:
        run: pytest --cov=aronnax -k 'Hypre and not 2X_2Y'
      - name: Upload coverage to Codecov
        uses: codecov/codecov-action@v3
+       with:
+        gcov: true
 
      - name: Run non-Hypre tests
        run: pytest --cov=aronnax -k 'not Hypre and not 2X_2Y'
      - name: Upload coverage to Codecov
        uses: codecov/codecov-action@v3
+       with:
+        gcov: true
 
  doc_html:
    runs-on: ubuntu-latest


### PR DESCRIPTION
Swapping from Travis to GitHub Actions led to no coverage data for Fortran code. This fixes that problem.