### PR TITLE
Enforce minimum layer thickness

### DIFF
--- a/src/barotropic_mode.f90
+++ b/src/barotropic_mode.f90
@@ -559,7 +559,7 @@ module barotropic_mode
 
   subroutine barotropic_correction(hnew, unew, vnew, eta, etanew, depth, a, &
       dx, dy, wetmask, hfac_w, hfac_s, dt, &
-      maxits, eps, rjac, freesurf_fac, thickness_error, &
+      maxits, eps, rjac, freesurf_fac, thickness_error, hmin, &
       debug_level, g_vec, nx, ny, layers, OL, &
       xlow, xhigh, ylow, yhigh, &
       n, MPI_COMM_WORLD, myid, num_procs, ilower, iupper, &
@@ -580,7 +580,7 @@ module barotropic_mode
     double precision, intent(in)    :: hfac_s(xlow-OL:xhigh+OL, ylow-OL:yhigh+OL)
     double precision, intent(in)    :: dt
     integer,          intent(in)    :: maxits
-    double precision, intent(in)    :: eps, rjac, freesurf_fac, thickness_error
+    double precision, intent(in)    :: eps, rjac, freesurf_fac, thickness_error, hmin
     integer,          intent(in)    :: debug_level
     double precision, intent(in)    :: g_vec(layers)
     integer,          intent(in)    :: nx, ny, layers, OL
@@ -674,7 +674,7 @@ module barotropic_mode
     ! between layer thicknesses and ocean depth by scaling
     ! thicknesses to agree with free surface.
     call enforce_depth_thickness_consistency(hnew, etanew, depth, &
-        freesurf_fac, thickness_error, xlow, xhigh, ylow, yhigh, layers, OL)
+        freesurf_fac, thickness_error, hmin, xlow, xhigh, ylow, yhigh, layers, OL)
 
     ! Apply the boundary conditions
     call apply_boundary_conditions(unew, hfac_w, wetmask, &

--- a/src/enforce_thickness.f90
+++ b/src/enforce_thickness.f90
@@ -8,14 +8,14 @@ module enforce_thickness
   !> Check that the free surface anomaly and layer thicknesses are consistent with the depth field. If they're not, then scale the layer thicnkesses to make them fit.
 
   subroutine enforce_depth_thickness_consistency(h, eta, depth, &
-      freesurf_fac, thickness_error, xlow, xhigh, ylow, yhigh, layers, OL)
+      freesurf_fac, thickness_error, hmin, xlow, xhigh, ylow, yhigh, layers, OL)
     implicit none
 
     double precision, intent(inout) :: h(xlow-OL:xhigh+OL, &
                                           ylow-OL:yhigh+OL, layers)
     double precision, intent(in) :: eta(xlow-OL:xhigh+OL, ylow-OL:yhigh+OL)
     double precision, intent(in) :: depth(xlow-OL:xhigh+OL, ylow-OL:yhigh+OL)
-    double precision, intent(in) :: freesurf_fac, thickness_error
+    double precision, intent(in) :: freesurf_fac, thickness_error, hmin
     integer, intent(in) :: xlow, xhigh, ylow, yhigh, layers, OL
 
     integer k
@@ -30,6 +30,10 @@ module enforce_thickness
       write(17, "(A, F6.3, A)") 'Inconsistency between h and eta: ', &
           maxval(abs(h_norming - 1d0))*100d0, '%'
     end if
+
+    where (h < hmin)
+        h = hmin
+    end where
 
     return
   end subroutine enforce_depth_thickness_consistency

--- a/src/model_main.f90
+++ b/src/model_main.f90
@@ -242,7 +242,7 @@ module model_main
       ! If they are not, then scale the layer thicknesses to make
       ! them consistent.
       call enforce_depth_thickness_consistency(h, eta, depth, &
-          freesurf_fac, thickness_error, &
+          freesurf_fac, thickness_error, hmin, &
           xlow, xhigh, ylow, yhigh, layers, OL)
     end if
 
@@ -350,7 +350,7 @@ module model_main
       if (.not. red_grav) then
         call barotropic_correction(h_new, u_new, v_new, eta, etanew, depth, a, &
             dx, dy, wetmask, hfac_w, hfac_s, dt, &
-            maxits, eps, rjac, freesurf_fac, thickness_error, &
+            maxits, eps, rjac, freesurf_fac, thickness_error, hmin, &
             debug_level, g_vec, nx, ny, layers, OL, &
             xlow, xhigh, ylow, yhigh, n, &
             MPI_COMM_WORLD, myid, num_procs, ilower, iupper, &


### PR DESCRIPTION
Previous behavoiur was to rapidly increase horizontal diffusion as layer thickness approached minimum allowed value. This usually worked, but not always. This revision strictly enforces the minimum layer thickness.