### PR TITLE
Flush python 3.6 requirement

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -70,8 +70,6 @@ jobs:
 
      - name: Set up Python
        uses: actions/setup-python@v2
-       with:
-         python-version: 3.6
 
      - name: install dependencies
        run:  |
@@ -93,8 +91,6 @@ jobs:
 
      - name: Set up Python
        uses: actions/setup-python@v2
-       with:
-         python-version: 3.6
 
      - name: install dependencies
        run: ./.github/workflows/install_doc_dependencies.sh


### PR DESCRIPTION
The github actions yaml had the python version pinned to 3.6. This version is no longer available. Pinned version has been removed. If everything passes, then there's no need to pin the version.