### PR TITLE
Add rtd yaml file in top level directory

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -30,6 +30,6 @@ sphinx:
 # Optional but recommended, declare the Python requirements required
 # to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-# python:
-#   install:
-#     - requirements: docs/requirements.txt
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,35 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+    # You can also specify other tool versions:
+    # nodejs: "20"
+    # rust: "1.70"
+    # golang: "1.20"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+  # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
+  # builder: "dirhtml"
+  # Fail on all warnings to avoid broken references
+  # fail_on_warning: true
+
+# Optionally build your docs in additional formats such as PDF and ePub
+# formats:
+#   - pdf
+#   - epub
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# python:
+#   install:
+#     - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,4 +5,4 @@ pandas
 toolz
 dask
 xarray
-
+sphinx-rtd-theme


### PR DESCRIPTION
Read the docs builds failed because there was no `.readthedocs.yaml` file in the top level directory. This PR fixes that issue by adding the default yaml file to the repo.